### PR TITLE
Replaced Write-Output with Write-Host to prevent pipeline corruption

### DIFF
--- a/src/agent-setup/codeql-install-windows.ps1
+++ b/src/agent-setup/codeql-install-windows.ps1
@@ -28,7 +28,7 @@ function Get-DownloadWithRetry {
         try
         {
             $downloadAttemptStartTime = Get-Date
-            Write-Output "Downloading package from: $Url to path $filePath ."
+            Write-Host "Downloading package from: $Url to path $filePath ."
             (New-Object System.Net.WebClient).DownloadFile($Url, $filePath)
             break
         }
@@ -36,23 +36,23 @@ function Get-DownloadWithRetry {
         {
             $failTime = [math]::Round(($(Get-Date) - $downloadStartTime).TotalSeconds, 2)
             $attemptTime = [math]::Round(($(Get-Date) - $downloadAttemptStartTime).TotalSeconds, 2)
-            Write-Output "There is an error encounterd after $attemptTime seconds during package downloading:`n $_"
+            Write-Host "There is an error encounterd after $attemptTime seconds during package downloading:`n $_"
             $Retries--
 
             if ($Retries -eq 0)
             {
-                Write-Output "File can't be downloaded. Please try later or check that file exists by url: $Url"
-                Write-Output "Total time elapsed $failTime"
+                Write-Host "File can't be downloaded. Please try later or check that file exists by url: $Url"
+                Write-Host "Total time elapsed $failTime"
                 exit 1
             }
 
-            Write-Output "Waiting 30 seconds before retrying. Retries left: $Retries"
+            Write-Host "Waiting 30 seconds before retrying. Retries left: $Retries"
             Start-Sleep -Seconds 30
         }
     }
 
     $downloadCompleteTime = [math]::Round(($(Get-Date) - $downloadStartTime).TotalSeconds, 2)
-    Write-Output "Package downloaded successfully in $downloadCompleteTime seconds"
+    Write-Host "Package downloaded successfully in $downloadCompleteTime seconds"
     return $filePath
 }
 
@@ -65,12 +65,12 @@ function Expand-7Zip {
         [string]$DestinationPath
     )
 
-    Write-Output "Expand archive '$PATH' to '$DestinationPath' directory"
+    Write-Host "Expand archive '$PATH' to '$DestinationPath' directory"
     7z.exe x "$Path" -o"$DestinationPath" -y | Out-Null
 
     if ($LASTEXITCODE -ne 0)
     {
-        Write-Output "There is an error during expanding '$Path' to '$DestinationPath' directory"
+        Write-Host "There is an error during expanding '$Path' to '$DestinationPath' directory"
         exit 1
     }
 }
@@ -98,14 +98,14 @@ $Bundles = @(
 )
 
 foreach ($Bundle in $Bundles) {
-    Write-Output "Downloading CodeQL bundle $($Bundle.BundleVersion)..."
+    Write-Host "Downloading CodeQL bundle $($Bundle.BundleVersion)..."
     $CodeQLBundlePath = Get-DownloadWithRetry -Url "https://github.com/github/codeql-action/releases/download/$($Bundle.TagName)/codeql-bundle.tar.gz" -Name "codeql-bundle.tar.gz"
     $DownloadDirectoryPath = (Get-Item $CodeQLBundlePath).Directory.FullName
 
     $CodeQLToolcachePath = Join-Path $Env:AGENT_TOOLSDIRECTORY -ChildPath "CodeQL" | Join-Path -ChildPath $Bundle.BundleVersion | Join-Path -ChildPath "x64"
     New-Item -Path $CodeQLToolcachePath -ItemType Directory -Force | Out-Null
 
-    Write-Output "Unpacking the downloaded CodeQL bundle archive..."
+    Write-Host "Unpacking the downloaded CodeQL bundle archive..."
     Expand-7Zip -Path $CodeQLBundlePath -DestinationPath $DownloadDirectoryPath
     $UnGzipedCodeQLBundlePath = Join-Path $DownloadDirectoryPath "codeql-bundle.tar"
     Expand-7Zip -Path $UnGzipedCodeQLBundlePath -DestinationPath $CodeQLToolcachePath


### PR DESCRIPTION
Tried to run the script on Windows machine, got weird behaviour.

`Write-Ouput` passes argument down the pipeline and if it happens that there is nowhere to pass it down, then prints out to the output.

This caused functions inside the script (like `Get-DownloadWithRetry` and `Expand-7Zip`) return arrays instead of single return values, containing first of all all the strings that were passed to `Write-Output` and lastly the actual return value.

This caused mayhem.

Replaced with `Write-Host` which outputs directly to stdout, everything worked out.