### PR TITLE
matrix - sample running mono repo scan in parallel

### DIFF
--- a/src/matrix/ghazdo-matrix.yml
+++ b/src/matrix/ghazdo-matrix.yml
@@ -1,0 +1,36 @@
+# Sample CodeQL matrix build for java and javascript
+#
+# To decrease your wall clock time inside a single pipeline with multiple languages, you might consider running jobs in parallel using a matrix strategy (https://learn.microsoft.com/en-us/azure/devops/pipelines/yaml-schema/jobs-job-strategy?view=azure-pipelines#strategy-matrix-maxparallel).
+# This strategy will require you to have multiple available parallel jobs available to take advantage of the concurrent work.
+# This can be achieved with organization level configuration (https://learn.microsoft.com/en-us/azure/devops/pipelines/licensing/concurrent-jobs) along with both Microsoft-hosted and self-hosted agents.
+# Also note that each Visual Studio Enterprise subscriber gets one self-hosted parallel job as a subscriber benefit!
+trigger:
+  - master
+
+pool:
+  vmImage: ubuntu-latest
+
+strategy:
+  matrix:
+    frontend:
+      language: javascript
+    backend:
+      language: java
+
+steps:
+  - task: AdvancedSecurity-Codeql-Init@1
+    inputs:
+      languages: "$(language)"
+
+  # Need to compile Java code while CodeQL tracer is running
+  - task: AdvancedSecurity-Codeql-Autobuild@1
+    #condition: eq('$(language)', 'java') - doesnt work always false, expands to null: https://stackoverflow.com/a/61093679/343347
+    condition: and(succeeded(), eq(variables.language, 'java'))
+
+  - task: AdvancedSecurity-Codeql-Analyze@1
+
+  # run dependency task for java, we are not doing anything dynamic with javascript in this pipeline - all languages will be picked up here
+  - task: AdvancedSecurity-Dependency-Scanning@1
+    condition: and(succeeded(), eq(variables.language, 'java'))
+
+  - task: AdvancedSecurity-Publish@1


### PR DESCRIPTION
 Sample CodeQL matrix build for java and javascript


>  To decrease your wall clock time inside a single pipeline with multiple languages, you might consider running jobs in parallel using a [matrix strategy](https://learn.microsoft.com/en-us/azure/devops/pipelines/yaml-schema/jobs-job-strategy?view=azure-pipelines#strategy-matrix-maxparallel).
> This strategy will require you to have multiple available parallel jobs available to take advantage of the concurrent work.
> This can be achieved with [organization level configuration](https://learn.microsoft.com/en-us/azure/devops/pipelines/licensing/concurrent-jobs) along with both Microsoft-hosted and self-hosted agents.
> Also note that each Visual Studio Enterprise subscriber gets one self-hosted parallel job as a subscriber benefit!


See file: [ghazdo-matrix.yml](https://github.com/microsoft/GHAzDO-Resources/blob/92246a7d7225c08b0d82df8ce5dc747dd482a1e7/src/matrix/ghazdo-matrix.yml)

# Before (9m wall clock time)

![image](https://github.com/microsoft/GHAzDO-Resources/assets/1760475/26c4bebf-25ba-4d00-bf61-fdaba347c671)

<img width="343" alt="image" src="https://github.com/microsoft/GHAzDO-Resources/assets/1760475/87a7f684-19e0-48b1-9077-74bc42bace42">

# After (4m wall clock time)

![image](https://github.com/microsoft/GHAzDO-Resources/assets/1760475/a46d3b04-1b82-4169-adee-bebd869836c1)

<img width="350" alt="image" src="https://github.com/microsoft/GHAzDO-Resources/assets/1760475/9b5347f5-8f70-421c-97e4-b19532d2880c">
