### PR TITLE
Fb pr gating

### DIFF
--- a/src/pr-gating/CIGate.ps1
+++ b/src/pr-gating/CIGate.ps1
@@ -61,7 +61,7 @@ if($newAlertIds.length -gt 0) {
             Write-Host  ""
             Write-Host  "##vso[task.logissue type=error;sourcepath=$($prAlert.physicalLocations.filePath);linenumber=$($prAlert.physicalLocations.region.lineStart);columnnumber=$($prAlert.physicalLocations.region.columnStart)] New $alertType alert detected #$($prAlert.alertId) : $($prAlert.title)."
             Write-Host  "##[error] Fix or dismiss this new alert in the Advanced Security UI for pr branch $($prSourceBranch)."
-            $urlAlert = "https://dev.azure.com/{0}/_git/{1}/alerts/{2}?branch={3}" -f $orgName, $project, $prAlert.alertId, $prSourceBranch
+            $urlAlert = "https://dev.azure.com/{0}/{1}/_git/{2}/alerts/{3}?branch={4}" -f $orgName, $project, $repositoryId, $prAlert.alertId, $prSourceBranch
             Write-Host  "##[error] Details for this new alert:  $($urlAlert)"
         }
     }

--- a/src/pr-gating/CIGate.ps1
+++ b/src/pr-gating/CIGate.ps1
@@ -1,9 +1,9 @@
 # This script is used as part of our PR gating strategy. It takes advantage of the GHAzDO REST API to check for CodeQL issues a PR source and target branch. 
-# If there are new issues in the PR source branch, the script will fail and block the PR merge. 
+# If there are new issues in the PR source branch, the script will fail and block the PR merge.
 $pass = ${env:MAPPED_ADO_PAT}
 $orgUri = ${env:SYSTEM_COLLECTIONURI}
 $orgName = $orgUri -replace "^https://dev.azure.com/|/$"
-$project = ${env:SYSTEM_TEAMPROJECT} 
+$project = ${env:SYSTEM_TEAMPROJECT}
 $mainBranch = ${env:SYSTEM_PULLREQUEST_TARGETBRANCH}
 $prBranch = ${env:BUILD_SOURCEBRANCH}
 $pair = ":${pass}"
@@ -15,14 +15,14 @@ $headers = @{ Authorization = $basicAuthValue }
 $urlMain = "https://advsec.dev.azure.com/{0}/{1}/_apis/Alert/repositories/{1}/Alerts?top=5000&orderBy=lastSeen&criteria.alertType=3&criteria.ref={2}&criteria.states=1" -f $orgName, $project, $mainBranch
 $urlPR =   "https://advsec.dev.azure.com/{0}/{1}/_apis/Alert/repositories/{1}/Alerts?top=5000&orderBy=lastSeen&criteria.alertType=3&criteria.ref={2}&criteria.states=1" -f $orgName, $project, $prBranch
 
-Write-Host "Will check to see if there are any new CodeQL issues in this PR branch" 
+Write-Host "Will check to see if there are any new CodeQL issues in this PR branch"
 
 if (${env:BUILD_REASON} -ne 'PullRequest'){
    Write-Host "This is not a PR into main so all is ok"
    exit 0
 }
 
-# Get the alerts on the main branch (all without filter) and the PR branch (only currently open) 
+# Get the alerts on the main branch (all without filter) and the PR branch (only currently open)
 $alertsMain = Invoke-WebRequest -Uri $urlMain -Headers $headers -Method Get
 $alertsPR = Invoke-WebRequest -Uri $urlPR -Headers $headers -Method Get
 
@@ -37,9 +37,9 @@ if ($alertsPR.StatusCode -ne 200){
 }
 
 $jsonMain = $alertsMain.Content | ConvertFrom-Json
-$jsonPR = $alertsPR.Content | ConvertFrom-Json 
+$jsonPR = $alertsPR.Content | ConvertFrom-Json
 
-# Extract alert ids from the list of alerts on main branch, the PR branch. 
+# Extract alert ids from the list of alerts on main branch, the PR branch.
 $mainAlertIds = $jsonMain.value | Select-Object -ExpandProperty alertId
 $prAlertIds = $jsonPR.value | Select-Object -ExpandProperty alertId
 
@@ -53,7 +53,7 @@ if($newAlertIds.length -gt 0) {
     # Loop over the objects in the prAlerts JSON object, log an error per new alert
     foreach ($prAlert in $jsonPR.value) {
         if ($newAlertIds -contains $prAlert.alertId) {
-            # This is a new Alert for this PR. Log and report it. 
+            # This is a new Alert for this PR. Log and report it.
             Write-Host  ""
             Write-Host  "##vso[task.logissue type=error;sourcepath=$($prAlert.physicalLocations.filePath);linenumber=$($prAlert.physicalLocations.region.lineStart);columnnumber=$($prAlert.physicalLocations.region.columnStart)] New CodeQL issue detected #$($prAlert.alertId) : $($prAlert.title)."
             Write-Host  "##[error] Fix or dismiss this new alert in the Advanced Security UI for pr branch $($prBranch)."
@@ -62,7 +62,7 @@ if($newAlertIds.length -gt 0) {
         }
     }
     Write-Host  ""
-    Write-Host "##[error] Please review these Code Scanning alerts for the $($prBranch) branch using the regular Advanced Security UI" 
+    Write-Host "##[error] Please review these Code Scanning alerts for the $($prBranch) branch using the regular Advanced Security UI"
     Write-Host "##[error] Dissmiss or fix the issues listed and try re-queue the CIVerify task."
     exit 1
 } else {

--- a/src/pr-gating/CIGate.ps1
+++ b/src/pr-gating/CIGate.ps1
@@ -1,0 +1,71 @@
+# This script is used as part of our PR gating strategy. It takes advantage of the GHAzDO REST API to check for CodeQL issues a PR source and target branch. 
+# If there are new issues in the PR source branch, the script will fail and block the PR merge. 
+$pass = ${env:MAPPED_ADO_PAT}
+$orgUri = ${env:SYSTEM_COLLECTIONURI}
+$orgName = $orgUri -replace "^https://dev.azure.com/|/$"
+$project = ${env:SYSTEM_TEAMPROJECT} 
+$mainBranch = ${env:SYSTEM_PULLREQUEST_TARGETBRANCH}
+$prBranch = ${env:BUILD_SOURCEBRANCH}
+$pair = ":${pass}"
+$bytes = [System.Text.Encoding]::ASCII.GetBytes($pair)
+$base64 = [System.Convert]::ToBase64String($bytes)
+$basicAuthValue = "Basic $base64"
+$headers = @{ Authorization = $basicAuthValue }
+
+$urlMain = "https://advsec.dev.azure.com/{0}/{1}/_apis/Alert/repositories/{1}/Alerts?top=5000&orderBy=lastSeen&criteria.alertType=3&criteria.ref={2}&criteria.states=1" -f $orgName, $project, $mainBranch
+$urlPR =   "https://advsec.dev.azure.com/{0}/{1}/_apis/Alert/repositories/{1}/Alerts?top=5000&orderBy=lastSeen&criteria.alertType=3&criteria.ref={2}&criteria.states=1" -f $orgName, $project, $prBranch
+
+Write-Host "Will check to see if there are any new CodeQL issues in this PR branch" 
+
+if (${env:BUILD_REASON} -ne 'PullRequest'){
+   Write-Host "This is not a PR into main so all is ok"
+   exit 0
+}
+
+# Get the alerts on the main branch (all without filter) and the PR branch (only currently open) 
+$alertsMain = Invoke-WebRequest -Uri $urlMain -Headers $headers -Method Get
+$alertsPR = Invoke-WebRequest -Uri $urlPR -Headers $headers -Method Get
+
+if ($alertsMain.StatusCode -ne 200){
+   Write-Host "##vso[task.logissue type=error] Error getting alerts from Azure DevOps Advanced Security Main:", $alertsMain.StatusCode, $alertsMain.StatusDescription
+   exit 1
+}
+
+if ($alertsPR.StatusCode -ne 200){
+   Write-Host "##vso[task.logissue type=error] Error getting alerts from Azure DevOps Advanced Security PR:", $alertsPR.StatusCode, $alertsPR.StatusDescription
+   exit 1
+}
+
+$jsonMain = $alertsMain.Content | ConvertFrom-Json
+$jsonPR = $alertsPR.Content | ConvertFrom-Json 
+
+# Extract alert ids from the list of alerts on main branch, the PR branch. 
+$mainAlertIds = $jsonMain.value | Select-Object -ExpandProperty alertId
+$prAlertIds = $jsonPR.value | Select-Object -ExpandProperty alertId
+
+# Check for alert ids that are reported in the PR branch but not the main branch
+$newAlertIds = Compare-Object $prAlertIds $mainAlertIds -PassThru | Where-Object { $_.SideIndicator -eq '<=' }
+
+# Are there any new alert ids in the PR branch?
+if($newAlertIds.length -gt 0) {
+    Write-Host "##[error] There are more alerts in the PR source branch $($prBranch), compared to main:"
+
+    # Loop over the objects in the prAlerts JSON object, log an error per new alert
+    foreach ($prAlert in $jsonPR.value) {
+        if ($newAlertIds -contains $prAlert.alertId) {
+            # This is a new Alert for this PR. Log and report it. 
+            Write-Host  ""
+            Write-Host  "##vso[task.logissue type=error;sourcepath=$($prAlert.physicalLocations.filePath);linenumber=$($prAlert.physicalLocations.region.lineStart);columnnumber=$($prAlert.physicalLocations.region.columnStart)] New CodeQL issue detected #$($prAlert.alertId) : $($prAlert.title)."
+            Write-Host  "##[error] Fix or dismiss this new alert in the Advanced Security UI for pr branch $($prBranch)."
+            $urlAlert = "https://dev.azure.com/{0}/_git/{1}/alerts/{2}?branch={3}" -f $orgName, $project, $prAlert.alertId, $prBranch
+            Write-Host  "##[error] Details for this new alert:  $($urlAlert)"
+        }
+    }
+    Write-Host  ""
+    Write-Host "##[error] Please review these Code Scanning alerts for the $($prBranch) branch using the regular Advanced Security UI" 
+    Write-Host "##[error] Dissmiss or fix the issues listed and try re-queue the CIVerify task."
+    exit 1
+} else {
+    Write-Output "No new CodeQL alerts - all is fine"
+    exit 0
+}

--- a/src/pr-gating/CIGate.ps1
+++ b/src/pr-gating/CIGate.ps1
@@ -1,71 +1,74 @@
 # This script is used as part of our PR gating strategy. It takes advantage of the GHAzDO REST API to check for CodeQL issues a PR source and target branch. 
-# If there are new issues in the PR source branch, the script will fail and block the PR merge.
+# If there are new issues in the source branch, the script will report on that and fail with error code 1. 
 $pass = ${env:MAPPED_ADO_PAT}
 $orgUri = ${env:SYSTEM_COLLECTIONURI}
 $orgName = $orgUri -replace "^https://dev.azure.com/|/$"
-$project = ${env:SYSTEM_TEAMPROJECT}
-$mainBranch = ${env:SYSTEM_PULLREQUEST_TARGETBRANCH}
-$prBranch = ${env:BUILD_SOURCEBRANCH}
+$project = ${env:SYSTEM_TEAMPROJECT} 
+$repositoryId = ${env:BUILD_REPOSITORY_ID} 
+$prTargetBranch = ${env:SYSTEM_PULLREQUEST_TARGETBRANCH}
+$prSourceBranch = ${env:BUILD_SOURCEBRANCH}
 $pair = ":${pass}"
 $bytes = [System.Text.Encoding]::ASCII.GetBytes($pair)
 $base64 = [System.Convert]::ToBase64String($bytes)
 $basicAuthValue = "Basic $base64"
 $headers = @{ Authorization = $basicAuthValue }
 
-$urlMain = "https://advsec.dev.azure.com/{0}/{1}/_apis/Alert/repositories/{1}/Alerts?top=5000&orderBy=lastSeen&criteria.alertType=3&criteria.ref={2}&criteria.states=1" -f $orgName, $project, $mainBranch
-$urlPR =   "https://advsec.dev.azure.com/{0}/{1}/_apis/Alert/repositories/{1}/Alerts?top=5000&orderBy=lastSeen&criteria.alertType=3&criteria.ref={2}&criteria.states=1" -f $orgName, $project, $prBranch
+$urlTargetAlerts = "https://advsec.dev.azure.com/{0}/{1}/_apis/AdvancedSecurity/Repositories/{2}/Alerts?top=5000&orderBy=lastSeen&criteria.alertType=3&criteria.branchName={3}&criteria.onlyDefaultBranchAlerts=true&useDatabaseProvider=true" -f $orgName, $project, $repositoryId, $prTargetBranch
+$urlSourceAlerts = "https://advsec.dev.azure.com/{0}/{1}/_apis/Alert/repositories/{1}/Alerts?top=5000&orderBy=lastSeen&criteria.alertType=3&criteria.ref={3}&criteria.states=1" -f $orgName, $project, $repositoryId, $prSourceBranch
 
-Write-Host "Will check to see if there are any new CodeQL issues in this PR branch"
+Write-Host "Will check to see if there are any new CodeQL issues in this PR branch" 
+Write-Host "PR source : $($prSourceBranch). PR target: $($prTargetBranch)"
 
 if (${env:BUILD_REASON} -ne 'PullRequest'){
    Write-Host "This is not a PR into main so all is ok"
    exit 0
 }
 
-# Get the alerts on the main branch (all without filter) and the PR branch (only currently open)
-$alertsMain = Invoke-WebRequest -Uri $urlMain -Headers $headers -Method Get
-$alertsPR = Invoke-WebRequest -Uri $urlPR -Headers $headers -Method Get
+# Get the alerts on the pr target branch (all without filter) and the PR source branch (only currently open)
+$alertsPRTarget = Invoke-WebRequest -Uri $urlTargetAlerts -Headers $headers -Method Get
+$alertsPRSource = Invoke-WebRequest -Uri $urlSourceAlerts -Headers $headers -Method Get
 
-if ($alertsMain.StatusCode -ne 200){
-   Write-Host "##vso[task.logissue type=error] Error getting alerts from Azure DevOps Advanced Security Main:", $alertsMain.StatusCode, $alertsMain.StatusDescription
+if ($alertsPRTarget.StatusCode -ne 200){
+   Write-Host "##vso[task.logissue type=error] Error getting alerts from Azure DevOps Advanced Security Main:", $alertsPRTarget.StatusCode, $alertsPRTarget.StatusDescription
    exit 1
 }
 
-if ($alertsPR.StatusCode -ne 200){
-   Write-Host "##vso[task.logissue type=error] Error getting alerts from Azure DevOps Advanced Security PR:", $alertsPR.StatusCode, $alertsPR.StatusDescription
+if ($alertsPRSource.StatusCode -ne 200){
+   Write-Host "##vso[task.logissue type=error] Error getting alerts from Azure DevOps Advanced Security PR:", $alertsPRSource.StatusCode, $alertsPRSource.StatusDescription
    exit 1
 }
 
-$jsonMain = $alertsMain.Content | ConvertFrom-Json
-$jsonPR = $alertsPR.Content | ConvertFrom-Json
+$jsonPRTarget = $alertsPRTarget.Content | ConvertFrom-Json
+$jsonPRSource = $alertsPRSource.Content | ConvertFrom-Json 
 
-# Extract alert ids from the list of alerts on main branch, the PR branch.
-$mainAlertIds = $jsonMain.value | Select-Object -ExpandProperty alertId
-$prAlertIds = $jsonPR.value | Select-Object -ExpandProperty alertId
+# Extract alert ids from the list of alerts on pr target/source branch.
+$prTargetAlertIds = $jsonPRTarget.value | Select-Object -ExpandProperty alertId
+$prSourceAlertIds = $jsonPRSource.value | Select-Object -ExpandProperty alertId
 
-# Check for alert ids that are reported in the PR branch but not the main branch
-$newAlertIds = Compare-Object $prAlertIds $mainAlertIds -PassThru | Where-Object { $_.SideIndicator -eq '<=' }
+# Check for alert ids that are reported in the PR source branch but not the pr target branch
+$newAlertIds = Compare-Object $prSourceAlertIds $prTargetAlertIds -PassThru | Where-Object { $_.SideIndicator -eq '<=' }
 
-# Are there any new alert ids in the PR branch?
+# Are there any new alert ids in the PR source branch?
 if($newAlertIds.length -gt 0) {
-    Write-Host "##[error] There are more alerts in the PR source branch $($prBranch), compared to main:"
+    Write-Host "##[error] There are more alerts in the PR source branch $($prSourceBranch), compared to target branch $($prTargetBranch) :"
 
-    # Loop over the objects in the prAlerts JSON object, log an error per new alert
-    foreach ($prAlert in $jsonPR.value) {
+    # Loop over the objects in the prAlerts JSON object
+    foreach ($prAlert in $jsonPRSource.value) {
         if ($newAlertIds -contains $prAlert.alertId) {
             # This is a new Alert for this PR. Log and report it.
             Write-Host  ""
             Write-Host  "##vso[task.logissue type=error;sourcepath=$($prAlert.physicalLocations.filePath);linenumber=$($prAlert.physicalLocations.region.lineStart);columnnumber=$($prAlert.physicalLocations.region.columnStart)] New CodeQL issue detected #$($prAlert.alertId) : $($prAlert.title)."
-            Write-Host  "##[error] Fix or dismiss this new alert in the Advanced Security UI for pr branch $($prBranch)."
-            $urlAlert = "https://dev.azure.com/{0}/_git/{1}/alerts/{2}?branch={3}" -f $orgName, $project, $prAlert.alertId, $prBranch
+            Write-Host  "##[error] Fix or dismiss this new alert in the Advanced Security UI for pr branch $($prSourceBranch)."
+            $urlAlert = "https://dev.azure.com/{0}/_git/{1}/alerts/{2}?branch={3}" -f $orgName, $project, $prAlert.alertId, $prSourceBranch
             Write-Host  "##[error] Details for this new alert:  $($urlAlert)"
         }
     }
-    Write-Host  ""
-    Write-Host "##[error] Please review these Code Scanning alerts for the $($prBranch) branch using the regular Advanced Security UI"
+    Write-Host
+    Write-Host "##[error] Please review these Code Scanning alerts for the $($prBranch) branch using the regular Advanced Security UI" 
     Write-Host "##[error] Dissmiss or fix the issues listed and try re-queue the CIVerify task."
     exit 1
 } else {
     Write-Output "No new CodeQL alerts - all is fine"
     exit 0
 }
+

--- a/src/pr-gating/CIGate.ps1
+++ b/src/pr-gating/CIGate.ps1
@@ -13,16 +13,14 @@ $base64 = [System.Convert]::ToBase64String($bytes)
 $basicAuthValue = "Basic $base64"
 $headers = @{ Authorization = $basicAuthValue }
 
-$alertType = "" # code,dependency,secret - If provided, only return alerts of this type. Otherwise, return alerts of all types.
+$urlTargetAlerts = "https://advsec.dev.azure.com/{0}/{1}/_apis/Alert/repositories/{2}/Alerts?top=500&orderBy=lastSeen&criteria.alertType=3&criteria.ref={3}&criteria.states=1" -f $orgName, $project, $repositoryId, $prTargetBranch
+$urlSourceAlerts = "https://advsec.dev.azure.com/{0}/{1}/_apis/Alert/repositories/{2}/Alerts?top=500&orderBy=lastSeen&criteria.alertType=3&criteria.ref={3}&criteria.states=1" -f $orgName, $project, $repositoryId, $prSourceBranch
 
-$urlTargetAlerts = "https://advsec.dev.azure.com/{0}/{1}/_apis/Alert/Repositories/{2}/Alerts?top=5000&orderBy=lastSeen&criteria.alertType={4}&criteria.branchName={3}&criteria.onlyDefaultBranchAlerts=true&useDatabaseProvider=true" -f $orgName, $project, $repositoryId, $prTargetBranch, $alertType
-$urlSourceAlerts = "https://advsec.dev.azure.com/{0}/{1}/_apis/Alert/repositories/{2}/Alerts?top=5000&orderBy=lastSeen&criteria.alertType={4}&criteria.ref={3}&criteria.states=1" -f $orgName, $project, $repositoryId, $prSourceBranch, $alertType
-
-Write-Host "Will check to see if there are any new $alertType alerts in this PR branch" 
+Write-Host "Will check to see if there are any new CodeQL issues in this PR branch" 
 Write-Host "PR source : $($prSourceBranch). PR target: $($prTargetBranch)"
 
 if (${env:BUILD_REASON} -ne 'PullRequest'){
-   Write-Host "This is not a PR into main so all is ok"
+   Write-Host "This build is not part of a Pull Request so all is ok"
    exit 0
 }
 
@@ -31,12 +29,12 @@ $alertsPRTarget = Invoke-WebRequest -Uri $urlTargetAlerts -Headers $headers -Met
 $alertsPRSource = Invoke-WebRequest -Uri $urlSourceAlerts -Headers $headers -Method Get
 
 if ($alertsPRTarget.StatusCode -ne 200){
-   Write-Host "##vso[task.logissue type=error] Error getting alerts from Azure DevOps Advanced Security Main:", $alertsPRTarget.StatusCode, $alertsPRTarget.StatusDescription
+   Write-Host "##vso[task.logissue type=error] Error getting alerts from Azure DevOps Advanced Security PR target branch:", $alertsPRTarget.StatusCode, $alertsPRTarget.StatusDescription
    exit 1
 }
 
 if ($alertsPRSource.StatusCode -ne 200){
-   Write-Host "##vso[task.logissue type=error] Error getting alerts from Azure DevOps Advanced Security PR:", $alertsPRSource.StatusCode, $alertsPRSource.StatusDescription
+   Write-Host "##vso[task.logissue type=error] Error getting alerts from Azure DevOps Advanced Security PR source branch:", $alertsPRSource.StatusCode, $alertsPRSource.StatusDescription
    exit 1
 }
 
@@ -52,7 +50,7 @@ $newAlertIds = Compare-Object $prSourceAlertIds $prTargetAlertIds -PassThru | Wh
 
 # Are there any new alert ids in the PR source branch?
 if($newAlertIds.length -gt 0) {
-    Write-Host "##[error] There are more alerts in the PR source branch $($prSourceBranch), compared to target branch $($prTargetBranch) :"
+    Write-Host "##[error] The code changes in this PR looks to be introducing new CodeQL alerts:"
 
     # Loop over the objects in the prAlerts JSON object
     foreach ($prAlert in $jsonPRSource.value) {
@@ -73,4 +71,3 @@ if($newAlertIds.length -gt 0) {
     Write-Output "No new CodeQL alerts - all is fine"
     exit 0
 }
-

--- a/src/pr-gating/CIGate.ps1
+++ b/src/pr-gating/CIGate.ps1
@@ -13,8 +13,8 @@ $base64 = [System.Convert]::ToBase64String($bytes)
 $basicAuthValue = "Basic $base64"
 $headers = @{ Authorization = $basicAuthValue }
 
-$urlTargetAlerts = "https://advsec.dev.azure.com/{0}/{1}/_apis/AdvancedSecurity/Repositories/{2}/Alerts?top=5000&orderBy=lastSeen&criteria.alertType=3&criteria.branchName={3}&criteria.onlyDefaultBranchAlerts=true&useDatabaseProvider=true" -f $orgName, $project, $repositoryId, $prTargetBranch
-$urlSourceAlerts = "https://advsec.dev.azure.com/{0}/{1}/_apis/Alert/repositories/{1}/Alerts?top=5000&orderBy=lastSeen&criteria.alertType=3&criteria.ref={3}&criteria.states=1" -f $orgName, $project, $repositoryId, $prSourceBranch
+$urlTargetAlerts = "https://advsec.dev.azure.com/{0}/{1}/_apis/Alert/Repositories/{2}/Alerts?top=5000&orderBy=lastSeen&criteria.alertType=3&criteria.branchName={3}&criteria.onlyDefaultBranchAlerts=true&useDatabaseProvider=true" -f $orgName, $project, $repositoryId, $prTargetBranch
+$urlSourceAlerts = "https://advsec.dev.azure.com/{0}/{1}/_apis/Alert/repositories/{2}/Alerts?top=5000&orderBy=lastSeen&criteria.alertType=3&criteria.ref={3}&criteria.states=1" -f $orgName, $project, $repositoryId, $prSourceBranch
 
 Write-Host "Will check to see if there are any new CodeQL issues in this PR branch" 
 Write-Host "PR source : $($prSourceBranch). PR target: $($prTargetBranch)"

--- a/src/pr-gating/CIVerify.yml
+++ b/src/pr-gating/CIVerify.yml
@@ -1,0 +1,46 @@
+# This is a starter pipeline to handle Gated PRs using GHAzDO. Currently (October 2023) this is not supported out of the box by the product, 
+# it probably will be supported in the future, this project can be used as a workaround until that time. 
+# We want to restrict new code going into main and only allow PRs if the new code does not introduce any new CodeQL issues. 
+# The idea is to set a branch protection policy (for main), forcing this pipeline to succeed before a PR into main can happen. 
+# The pipeline will run CodeQL on the source branch of the PR. Later, using a PowerShell script, the CodeQL issues of the PR source and target will be compared. 
+# If there are issues in the PR source that are not in main, this pipeline will fail. 
+#
+# If new alerts are detected these needs to be analysed using the regular Advanced Security Code Scanning UI. Set the filter to the pr branch and fix or dissmiss all the new issue. 
+# After that, the PR check CIVerify can be requeued in the PR. Hopefully this time, without any issues. 
+# 
+# The script needs a PAT to run (for accessing the REST API). This PAT should be setup as a secret variable for the pipleline (name: GATING_PAT). 
+# The PAT needs the access right - Advanced Security - Read
+#
+# More on ADO build verifications: https://learn.microsoft.com/en-us/azure/devops/repos/git/branch-policies?view=azure-devops&tabs=browser#build-validation 
+
+trigger:
+- none
+
+pool:
+  vmImage: ubuntu-latest
+  
+# Variables for CodeQL
+variables:
+  SourcesFolder: src\main
+   
+
+steps:
+# Run CodeQL on this branch (source branch of the PR) 
+- task: AdvancedSecurity-Codeql-Init@1
+  inputs:
+    languages: 'javascript'
+    querysuite: 'code-scanning'
+
+- task: AdvancedSecurity-Codeql-Autobuild@1
+- task: AdvancedSecurity-Codeql-Analyze@1
+- task: AdvancedSecurity-Publish@1
+
+# Compair CodeQL issues on the PR source branch and main. 
+# Fail if there are new issues.  
+- task: PowerShell@2
+  displayName: 'CI Gating - verify there are no new CodeQL issues introduced in this PR'
+  inputs:
+    targetType: filePath
+    filePath: CIGate.ps1
+  env:
+    MAPPED_ADO_PAT: $(GATING_PAT)

--- a/src/pr-gating/CIVerify.yml
+++ b/src/pr-gating/CIVerify.yml
@@ -33,7 +33,6 @@ steps:
 
 - task: AdvancedSecurity-Codeql-Autobuild@1
 - task: AdvancedSecurity-Codeql-Analyze@1
-- task: AdvancedSecurity-Publish@1
 
 # Compair CodeQL issues on the PR source branch and main. 
 # Fail if there are new issues.  

--- a/src/pr-gating/CIVerify.yml
+++ b/src/pr-gating/CIVerify.yml
@@ -29,7 +29,6 @@ steps:
 - task: AdvancedSecurity-Codeql-Init@1
   inputs:
     languages: 'javascript'
-    querysuite: 'code-scanning'
 
 - task: AdvancedSecurity-Codeql-Autobuild@1
 - task: AdvancedSecurity-Codeql-Analyze@1

--- a/src/pr-gating/README.md
+++ b/src/pr-gating/README.md
@@ -4,7 +4,7 @@ Pipeline and script to handle Gated PRs using Advanced Security for ADO. Current
 The idea is to set a branch protection policy (for main or any other branch), forcing the verification pipeline to succeed before a PR into the branch can happen. The pipeline will run a CodeQL scan on the source branch of the PR. Later, using a PowerShell script, the CodeQL issues of the PR source and target will be compared. If there are issues in the PR source that are not in the PR target this pipeline will fail. 
 If new alerts are detected, these will have to be analysed using the regular Advanced Security UI for Code Scanning alerts. Set the branch filter to the new PR branch and fix or dismiss the new alerts. After that, the CIVerify Check for the PR can be re-run, hopefully this time with no issues.
 
-If fixing the alerts is not the right choice and you do not have the rights to dismiss the alerts, one option is to setup this Check as optional. That way, a PR merge can still happen, even if you think the check failed and reported a new issue. 
+If fixing the alerts is not the right choice and you do not have the rights to dismiss the alerts, one option is to setup this Check as optional. That way, a PR merge can still happen, even if the check failed and reported a new issue, this is mainly useful for false positives. 
 
 
 [Setup](./Setup.md)

--- a/src/pr-gating/README.md
+++ b/src/pr-gating/README.md
@@ -1,0 +1,9 @@
+# GHAzDO Pr-Gating
+Pipeline and script to handle Gated PRs using Advanced Security for ADO. Currently (October 2023) this is not supported out of the box by the product. We want to restrict new code going into main and only allow PRs if the new code does not introduce any new CodeQL issues. The same could be done for Dependencies with some tweaks.
+
+The idea is to set a branch protection policy (for main), forcing this pipeline to succeed before a PR into main can happen. The pipeline will run a CodeQL scan on the source branch of the PR. Later, using a PowerShell script, the CodeQL issues of the PR source and target will be compared. If there are issues in the PR source that are not in the PR target this pipeline will fail. 
+If new alerts are detected, these will have to be analysed using the regular Advanced Security UI for Code Scanning alerts. Set the branch filter to the new PR branch and fix or dismiss the new alerts. After that, the CIVerify Check for the PR can be re-run, hopefully this time with no issues.
+
+[Setup](./Setup.md)
+
+[Usage](./Usage.md)

--- a/src/pr-gating/README.md
+++ b/src/pr-gating/README.md
@@ -1,4 +1,4 @@
-# GHAzDO Pr-Gating
+# GHAzDO PR-Gating
 Pipeline and script to handle Gated PRs using Advanced Security for ADO. Currently (October 2023) this is not supported out of the box by the product. We want to restrict new code going into main and only allow PRs if the new code does not introduce any new CodeQL issues. The same could be done for Dependencies with some tweaks.
 
 The idea is to set a branch protection policy (for main), forcing this pipeline to succeed before a PR into main can happen. The pipeline will run a CodeQL scan on the source branch of the PR. Later, using a PowerShell script, the CodeQL issues of the PR source and target will be compared. If there are issues in the PR source that are not in the PR target this pipeline will fail. 

--- a/src/pr-gating/README.md
+++ b/src/pr-gating/README.md
@@ -1,11 +1,10 @@
 # GHAzDO PR-Gating
-Pipeline and script to handle Gated PRs using Advanced Security for ADO. Currently (October 2023) this is not supported out of the box by the product. We want to restrict new code going into main and only allow PRs if the new code does not introduce any new CodeQL issues. The same could be done for Dependencies with some tweaks.
+Pipeline and script to handle Gated PRs using Advanced Security for ADO. Currently (November 2023) this is not supported out of the box by the product. We want to restrict new code going into main and only allow PRs if the new code does not introduce any new CodeQL issues. The same could be done for Dependencies with some tweaks.
 
-The idea is to set a branch protection policy (for main or any other branch), forcing the verification pipeline to succeed before a PR into the branch can happen. The pipeline will run a CodeQL scan on the source branch of the PR. Later, using a PowerShell script, the CodeQL issues of the PR source and target will be compared. If there are issues in the PR source that are not in the PR target this pipeline will fail. 
+The idea is to set a branch protection policy (for main), forcing this pipeline to succeed before a PR into main can happen. The pipeline will run a CodeQL scan on the source branch of the PR. Later, using a PowerShell script, the CodeQL issues of the PR source and target will be compared. If there are issues in the PR source that are not in the PR target this pipeline will fail. 
 If new alerts are detected, these will have to be analysed using the regular Advanced Security UI for Code Scanning alerts. Set the branch filter to the new PR branch and fix or dismiss the new alerts. After that, the CIVerify Check for the PR can be re-run, hopefully this time with no issues.
 
-If fixing the alerts is not the right choice and you do not have the rights to dismiss the alerts, one option is to setup this Check as optional. That way, a PR merge can still happen, even if the check failed and reported a new issue, this is mainly useful for false positives. 
-
+If fixing the alerts is not the right choice and you do not have the rights to dismiss the alerts, one option is to setup this Check as optional. That way, a PR merge can still happen, even if the check failed and reported a new issue. This is mainly useful for false positives. 
 
 [Setup](./Setup.md)
 

--- a/src/pr-gating/README.md
+++ b/src/pr-gating/README.md
@@ -1,8 +1,11 @@
 # GHAzDO PR-Gating
 Pipeline and script to handle Gated PRs using Advanced Security for ADO. Currently (October 2023) this is not supported out of the box by the product. We want to restrict new code going into main and only allow PRs if the new code does not introduce any new CodeQL issues. The same could be done for Dependencies with some tweaks.
 
-The idea is to set a branch protection policy (for main), forcing this pipeline to succeed before a PR into main can happen. The pipeline will run a CodeQL scan on the source branch of the PR. Later, using a PowerShell script, the CodeQL issues of the PR source and target will be compared. If there are issues in the PR source that are not in the PR target this pipeline will fail. 
+The idea is to set a branch protection policy (for main or any other branch), forcing the verification pipeline to succeed before a PR into the branch can happen. The pipeline will run a CodeQL scan on the source branch of the PR. Later, using a PowerShell script, the CodeQL issues of the PR source and target will be compared. If there are issues in the PR source that are not in the PR target this pipeline will fail. 
 If new alerts are detected, these will have to be analysed using the regular Advanced Security UI for Code Scanning alerts. Set the branch filter to the new PR branch and fix or dismiss the new alerts. After that, the CIVerify Check for the PR can be re-run, hopefully this time with no issues.
+
+If fixing the alerts is not the right choice and you do not have the rights to dismiss the alerts, one option is to setup this Check as optional. That way, a PR merge can still happen, even if you think the check failed and reported a new issue. 
+
 
 [Setup](./Setup.md)
 

--- a/src/pr-gating/Setup.md
+++ b/src/pr-gating/Setup.md
@@ -25,7 +25,7 @@
 
   Find your new pipeline in the ADO UI, [rename it](https://learn.microsoft.com/en-us/azure/devops/pipelines/customize-pipeline?view=azure-devops#pipeline-settings) to CIVerify.
 
-- Setup [build verification for your main branch](https://learn.microsoft.com/en-us/azure/devops/repos/git/branch-policies?view=azure-devops&tabs=browser#build-validation). Pick the CIVerify pipeline, you can keep the rest of the default settings.
+- Setup [build verification for your main branch](https://learn.microsoft.com/en-us/azure/devops/repos/git/branch-policies?view=azure-devops&tabs=browser#build-validation). Pick the CIVerify pipeline. If your developers does not have access rights to dissmiss alerts it is a good idea to set this check to optional. That way, a PR can happen even if the alert is a false possitive. The rest of the settings can be keep as their default settings.
 
 <img width="800" alt="buildpolicy" src="https://github.com/microsoft/GHAzDO-Resources/assets/106392052/74801e80-46e1-4d05-97b1-5f11396330e1">
 
@@ -36,6 +36,6 @@
 - The CodeQL language (javascript) is hardcoded in CIVerify.yml. GHAzDO settings will need to be updated to match your needs. 
 - The CI Verification could be extended to also (or only) check new Dependency alerts. The same strategy could be used but tweaks would have to be done to both CIVerify.yml and CIGate.ps1. 
 One complication to concider if you want to use the same strategy for dependency scanning. It could be that the reason we see new issues reported is that the advisory database has been extended since the last scan of main. That is, the new additions in the PR is not the issue but rather that this scan is the first one after an extention of the known vunarabilities. Still, since the alerts can be dismissed in the PR branch, or a new scan can be run on the main branch, I think this is acceptable. 
-- Currently it is hard coded that we compaire to the main branch. If you have a different merge strategy, CIVerify.yml and CIGate.ps1 can be updated to accommodate that. 
+
 
    

--- a/src/pr-gating/Setup.md
+++ b/src/pr-gating/Setup.md
@@ -27,6 +27,8 @@
 
 - Setup [build verification for your main branch](https://learn.microsoft.com/en-us/azure/devops/repos/git/branch-policies?view=azure-devops&tabs=browser#build-validation). Pick the CIVerify pipeline, you can keep the rest of the default settings.
 
+<img width="800" alt="buildpolicy" src="https://github.com/microsoft/GHAzDO-Resources/assets/106392052/74801e80-46e1-4d05-97b1-5f11396330e1">
+
 
 - Figure out a way to test your new setup without adding any bad code to your main branch :) 
 

--- a/src/pr-gating/Setup.md
+++ b/src/pr-gating/Setup.md
@@ -1,0 +1,39 @@
+## Setup
+
+- Copy the two files CIGate.ps1 and CIVerify.yml into your own GHAzDO enabled ADO project repo.
+
+- Generate a new [PAT for ADO](https://learn.microsoft.com/en-us/azure/devops/organizations/accounts/use-personal-access-tokens-to-authenticate).
+  
+  You can call it GHAZDO_READ_PAT, pick an expiry date.
+
+  Give the new PAT ```Advanced Security - READ``` access.
+
+  Save the PAT key before closing the UI.
+
+
+- Add CIVerify as a new pipeline.
+  
+  Pipelines - New Pipeline - Select your code location and configure your pipeline as an existing yaml file.
+
+  Select the CIVerify.yml file that was added in step 1.  Save the new Pipeline.
+
+  Review the .yaml file, open up the UI to add a new Variable.
+
+  Add a variable called GATING_PAT and set it's content to the PAT key you got in the previus step.
+
+  Save your pipeline and optionaly run it.
+
+  Find your new pipeline in the ADO UI, [rename it](https://learn.microsoft.com/en-us/azure/devops/pipelines/customize-pipeline?view=azure-devops#pipeline-settings) to CIVerify.
+
+- Setup [build verification for your main branch](https://learn.microsoft.com/en-us/azure/devops/repos/git/branch-policies?view=azure-devops&tabs=browser#build-validation). Pick the CIVerify pipeline, you can keep the rest of the default settings.
+
+
+- Figure out a way to test your new setup without adding any bad code to your main branch :) 
+
+## Possible customizations
+- Currently both language (javascript) and query suites (security-extended) are hard coded in CIVerify.yml. These settings might have to be updated to match your needs. 
+- The CI Verification could be extended to also (or only) check new Dependency alerts. The same strategy could be used but tweaks would have to be done to both CIVerify.yml and CIGate.ps1. 
+One complication to concider if you want to use the same strategy for dependency scanning. It could be that the reason we see new issues reported is that the advisory database has been extended since the last scan of main. That is, the new additions in the PR is not the issue but rather that this scan is the first one after an extention of the known vunarabilities. Still, since the alerts can be dismissed in the PR branch, or a new scan can be run on the main branch, I think this is acceptable. 
+- Currently it is hard coded that we compaire to the main branch. If you have a different merge strategy, CIVerify.yml and CIGate.ps1 can be updated to accommodate that. 
+
+   

--- a/src/pr-gating/Setup.md
+++ b/src/pr-gating/Setup.md
@@ -26,6 +26,7 @@
   Find your new pipeline in the ADO UI, [rename it](https://learn.microsoft.com/en-us/azure/devops/pipelines/customize-pipeline?view=azure-devops#pipeline-settings) to CIVerify.
 
 - Setup [build verification for your main branch](https://learn.microsoft.com/en-us/azure/devops/repos/git/branch-policies?view=azure-devops&tabs=browser#build-validation). Pick the CIVerify pipeline. If your developers does not have access rights to dissmiss alerts it is a good idea to set this check to optional. That way, a PR can happen even if the alert is a false possitive. The rest of the settings can be keep as their default settings.
+Optionaly, if you have more branches that should be protected, you can setup the same check for those branches. 
 
 <img width="800" alt="buildpolicy" src="https://github.com/microsoft/GHAzDO-Resources/assets/106392052/74801e80-46e1-4d05-97b1-5f11396330e1">
 

--- a/src/pr-gating/Setup.md
+++ b/src/pr-gating/Setup.md
@@ -33,7 +33,7 @@
 - Figure out a way to test your new setup without adding any bad code to your main branch :) 
 
 ## Possible customizations
-- Currently both language (javascript) and query suites (security-extended) are hard coded in CIVerify.yml. These settings might have to be updated to match your needs. 
+- The CodeQL language (javascript) is hardcoded in CIVerify.yml. GHAzDO settings will need to be updated to match your needs. 
 - The CI Verification could be extended to also (or only) check new Dependency alerts. The same strategy could be used but tweaks would have to be done to both CIVerify.yml and CIGate.ps1. 
 One complication to concider if you want to use the same strategy for dependency scanning. It could be that the reason we see new issues reported is that the advisory database has been extended since the last scan of main. That is, the new additions in the PR is not the issue but rather that this scan is the first one after an extention of the known vunarabilities. Still, since the alerts can be dismissed in the PR branch, or a new scan can be run on the main branch, I think this is acceptable. 
 - Currently it is hard coded that we compaire to the main branch. If you have a different merge strategy, CIVerify.yml and CIGate.ps1 can be updated to accommodate that. 

--- a/src/pr-gating/Setup.md
+++ b/src/pr-gating/Setup.md
@@ -1,15 +1,14 @@
 ## Setup
-
+  
 - Copy the two files CIGate.ps1 and CIVerify.yml into your own GHAzDO enabled ADO project repo.
 
 - Generate a new [PAT for ADO](https://learn.microsoft.com/en-us/azure/devops/organizations/accounts/use-personal-access-tokens-to-authenticate).
   
-  You can call it GHAZDO_READ_PAT, pick an expiry date.
+  You can call it GHAZDO_PRGATING_PAT, pick an expiry date.
 
-  Give the new PAT ```Advanced Security - READ``` access.
+  Give the new PAT ```Advanced Security - Read, Code - Read, Pull Request Threads - Read & write``` access.
 
-  Save the PAT key before closing the UI.
-
+  Save the generated PAT key before closing the UI.
 
 - Add CIVerify as a new pipeline.
   
@@ -25,10 +24,13 @@
 
   Find your new pipeline in the ADO UI, [rename it](https://learn.microsoft.com/en-us/azure/devops/pipelines/customize-pipeline?view=azure-devops#pipeline-settings) to CIVerify.
 
-- Setup [build verification for your main branch](https://learn.microsoft.com/en-us/azure/devops/repos/git/branch-policies?view=azure-devops&tabs=browser#build-validation). Pick the CIVerify pipeline. If your developers does not have access rights to dissmiss alerts it is a good idea to set this check to optional. That way, a PR can happen even if the alert is a false possitive. The rest of the settings can be keep as their default settings.
-Optionaly, if you have more branches that should be protected, you can setup the same check for those branches. 
+- Setup [build verification for your main branch](https://learn.microsoft.com/en-us/azure/devops/repos/git/branch-policies?view=azure-devops&tabs=browser#build-validation). Pick the CIVerify pipeline. If your developers does not have access rights to dissmiss alerts it is a good idea to set this check to optional. That way, a PR can be completed even if the alert is a false possitive. The rest of the settings can be keep as their default settings.
 
-<img width="800" alt="buildpolicy" src="https://github.com/microsoft/GHAzDO-Resources/assets/106392052/74801e80-46e1-4d05-97b1-5f11396330e1">
+  The CIVerify pipeline will add PR annotations as comments for the code related to the new alert. Concider setting the requirement 'Check for comment resolution' as a branch policy. This will require all CodeQL generated comments to be concidered before completing the merge. 
+
+  If you have more branches that should be protected, you can setup the same check for those branches.
+  
+  <img width="800" alt="buildpolicy" src="https://github.com/microsoft/GHAzDO-Resources/assets/106392052/74801e80-46e1-4d05-97b1-5f11396330e1">
 
 
 - Figure out a way to test your new setup without adding any bad code to your main branch :) 
@@ -38,5 +40,3 @@ Optionaly, if you have more branches that should be protected, you can setup the
 - The CI Verification could be extended to also (or only) check new Dependency alerts. The same strategy could be used but tweaks would have to be done to both CIVerify.yml and CIGate.ps1. 
 One complication to concider if you want to use the same strategy for dependency scanning. It could be that the reason we see new issues reported is that the advisory database has been extended since the last scan of main. That is, the new additions in the PR is not the issue but rather that this scan is the first one after an extention of the known vunarabilities. Still, since the alerts can be dismissed in the PR branch, the branch policy check can be setup as optional, or a new scan can be run on the main branch, I think this is acceptable. 
 
-
-   

--- a/src/pr-gating/Setup.md
+++ b/src/pr-gating/Setup.md
@@ -36,7 +36,7 @@ Optionaly, if you have more branches that should be protected, you can setup the
 ## Possible customizations
 - The CodeQL language (javascript) is hardcoded in CIVerify.yml. GHAzDO settings will need to be updated to match your needs. 
 - The CI Verification could be extended to also (or only) check new Dependency alerts. The same strategy could be used but tweaks would have to be done to both CIVerify.yml and CIGate.ps1. 
-One complication to concider if you want to use the same strategy for dependency scanning. It could be that the reason we see new issues reported is that the advisory database has been extended since the last scan of main. That is, the new additions in the PR is not the issue but rather that this scan is the first one after an extention of the known vunarabilities. Still, since the alerts can be dismissed in the PR branch, or a new scan can be run on the main branch, I think this is acceptable. 
+One complication to concider if you want to use the same strategy for dependency scanning. It could be that the reason we see new issues reported is that the advisory database has been extended since the last scan of main. That is, the new additions in the PR is not the issue but rather that this scan is the first one after an extention of the known vunarabilities. Still, since the alerts can be dismissed in the PR branch, the branch policy check can be setup as optional, or a new scan can be run on the main branch, I think this is acceptable. 
 
 
    

--- a/src/pr-gating/Usage.md
+++ b/src/pr-gating/Usage.md
@@ -15,25 +15,22 @@ Save the file and create a new Pull Request from the new branch into main.
 
 The CIVerify pipeline will run as part of the checks for this PR. This check will fail and issues with the new code will be reported.
 
-<img width="800" alt="1check" src="https://github.com/microsoft/GHAzDO-Resources/assets/106392052/300c4794-a709-4340-acef-a134a6556e58">
+<img width="800" alt="CIVerify fail" src="https://github.com/microsoft/GHAzDO-Resources/assets/106392052/99dbf004-7d45-4d53-a6a5-8a9027ac980c">
 
+An annotation has also been added to the file that contains the CodeQL issue. 
 
-Clicking the error will bring you to the CIVerify Pipeline run. You will see two errors listed for the Pipeline. One referencing to the new bad code, one just noting that CIVerify failed. 
+<img width="800" alt="PR annotation" src="https://github.com/microsoft/GHAzDO-Resources/assets/106392052/4a3d1a1b-722d-4596-889e-ab3190350ae4">
 
-<img width="800" alt="2errorlogs" src="https://github.com/microsoft/GHAzDO-Resources/assets/106392052/2dcb1ca7-13f4-4a96-872b-e83a1b9381a4">
+The annotation will be in the name of the person that created the PAT that is being used by the pipeline (GHAZDO_PRGATING_PAT). 
+Open the 'See details here' link and review the alert. 
 
+In most scenarios, the best option will be to fix the code so that the alert disapears. If this is a false possitive and you have the access rights, you can dismiss the alert. 
 
-Open up the logs for the first error. You will be able to see the CodeQL error message, alert id and also have a link to the new alert that was detected. 
+<img width="800" alt="Alert review" src="https://github.com/microsoft/GHAzDO-Resources/assets/106392052/caad17cd-9c3d-431a-9045-ad681bbc8da8">
 
-<img width="800" alt="3logtext" src="https://github.com/microsoft/GHAzDO-Resources/assets/106392052/7f634b98-d34a-4b40-ae9e-37f4cfb61fc4">
+You should also close the comment that was added to the PR.
 
-
-Select the link and jump to the new alert.  Review the alert, fix or dismiss this alert. 
-
-
-<img width="800" alt="ReviewCloseAlert" src="https://github.com/microsoft/GHAzDO-Resources/assets/106392052/b7ec3938-a1cf-4001-9e6d-59c62bfdc873">
-
-
+<img width="800" alt="Close comment" src="https://github.com/microsoft/GHAzDO-Resources/assets/106392052/9a75487a-6ce0-4962-ae57-4c0708bc8f9b">
 
 Re-queue the CIVerify check again in the PR. 
 This time the check should pass with not issue.    

--- a/src/pr-gating/Usage.md
+++ b/src/pr-gating/Usage.md
@@ -15,21 +15,29 @@ Save the file and create a new Pull Request from the new branch into main.
 
 The CIVerify pipeline will run as part of the checks for this PR. This check will fail and issues with the new code will be reported.
 
+<img width="800" alt="1check" src="https://github.com/microsoft/GHAzDO-Resources/assets/106392052/300c4794-a709-4340-acef-a134a6556e58">
 
 
 Clicking the error will bring you to the CIVerify Pipeline run. You will see two errors listed for the Pipeline. One referencing to the new bad code, one just noting that CIVerify failed. 
 
+<img width="800" alt="2errorlogs" src="https://github.com/microsoft/GHAzDO-Resources/assets/106392052/2dcb1ca7-13f4-4a96-872b-e83a1b9381a4">
+
 
 Open up the logs for the first error. You will be able to see the CodeQL error message, alert id and also have a link to the new alert that was detected. 
 
+<img width="800" alt="3logtext" src="https://github.com/microsoft/GHAzDO-Resources/assets/106392052/7f634b98-d34a-4b40-ae9e-37f4cfb61fc4">
 
-Select the link and jump to the new alert. 
-Review the alert, fix or dismiss this alert. 
+
+Select the link and jump to the new alert.  Review the alert, fix or dismiss this alert. 
+
+
+<img width="800" alt="ReviewCloseAlert" src="https://github.com/microsoft/GHAzDO-Resources/assets/106392052/b7ec3938-a1cf-4001-9e6d-59c62bfdc873">
 
 
 
 Re-queue the CIVerify check again in the PR. 
 This time the check should pass with not issue.    
 
+<img width="800" alt="CheckOk" src="https://github.com/microsoft/GHAzDO-Resources/assets/106392052/021403d8-96dd-4246-a7cc-9ee95df88a04">
 
 

--- a/src/pr-gating/Usage.md
+++ b/src/pr-gating/Usage.md
@@ -1,0 +1,35 @@
+## Usage
+
+After setup, all PRs into main will have CIVerify as a PR verification check.
+
+For the code in this repo, one way to test the setup is to create a new branch based on main. Update the index.js file in the new branch to include these lines, after line 34
+
+```
+// This code will generate a CodeQL rate limit alert
+app.get('/mybadcode', (req, res) => {
+  res.sendFile('form.html', { root: __dirname });
+});
+```
+
+Save the file and create a new Pull Request from the new branch into main. 
+
+The CIVerify pipeline will run as part of the checks for this PR. This check will fail and issues with the new code will be reported.
+
+
+
+Clicking the error will bring you to the CIVerify Pipeline run. You will see two errors listed for the Pipeline. One referencing to the new bad code, one just noting that CIVerify failed. 
+
+
+Open up the logs for the first error. You will be able to see the CodeQL error message, alert id and also have a link to the new alert that was detected. 
+
+
+Select the link and jump to the new alert. 
+Review the alert, fix or dismiss this alert. 
+
+
+
+Re-queue the CIVerify check again in the PR. 
+This time the check should pass with not issue.    
+
+
+

--- a/src/pr-gating/index.js
+++ b/src/pr-gating/index.js
@@ -1,0 +1,60 @@
+'use strict';
+
+const express = require('express');
+const bodyParser = require('body-parser')
+const version = require('./version');
+const { Pool } = require('pg');
+
+// Load environment
+require('dotenv').config()
+
+// Database pool
+const pool = new Pool({
+  user: process.env.DB_USERNAME,
+  host: process.env.DB_HOST,
+  database: process.env.DB_NAME,
+  password: process.env.DB_PASSWORD,
+  port: process.env.DB_PORT,
+})
+
+// Application
+const app = express();
+app.use(bodyParser.json())
+app.use(bodyParser.urlencoded({
+  extended: true
+}));
+
+const port = process.env.PORT || 8080;
+
+// Route - default
+app.get('/', (req, res) => {
+  res.status(200).send(JSON.stringify({ name: version.getName(), version: version.getVersion() }));
+});
+
+app.get('/mybadcode', (req, res) => {
+  res.sendFile('form.html', { root: __dirname });
+});
+
+// Route - user search
+app.get("/users", function (req, res) {
+  let search = "%";
+
+  if (req?.params?.q) {
+    search = req.params.q;
+  }
+
+  const squery = `SELECT * FROM users WHERE name LIKE '${search}';`
+  pool.query(squery, (err, results) => {
+    if (err) {
+      console.log(err, results)
+    }
+    else {
+      res.send(results.rows)
+    }
+  });
+});
+
+// Start the server
+app.listen(port, () => {
+  console.log(`Express app up and running on http://localhost:${port}`);
+})

--- a/src/pr-gating/index.js
+++ b/src/pr-gating/index.js
@@ -31,10 +31,6 @@ app.get('/', (req, res) => {
   res.status(200).send(JSON.stringify({ name: version.getName(), version: version.getVersion() }));
 });
 
-app.get('/mybadcode', (req, res) => {
-  res.sendFile('form.html', { root: __dirname });
-});
-
 // Route - user search
 app.get("/users", function (req, res) {
   let search = "%";


### PR DESCRIPTION
Pipeline and script to handle Gated PRs using Advanced Security for ADO. Currently (October 2023) this is not supported out of the box by the product. We want to restrict new code going into main and only allow PRs if the new code does not introduce any new CodeQL issues. The same could be done for Dependencies with some tweaks.

The idea is to set a branch protection policy (for main), forcing this pipeline to succeed before a PR into main can happen. The pipeline will run a CodeQL scan on the source branch of the PR. Later, using a PowerShell script, the CodeQL issues of the PR source and target will be compared. If there are issues in the PR source that are not in the PR target this pipeline will fail. If new alerts are detected, these will have to be analysed using the regular Advanced Security UI for Code Scanning alerts. Set the branch filter to the new PR branch and fix or dismiss the new alerts. After that, the CIVerify Check for the PR can be re-run, hopefully this time with no issues.

