### PR TITLE
Modify API URL to retrieve alerts in the gating example

### DIFF
--- a/src/gating/gating.ps1
+++ b/src/gating/gating.ps1
@@ -30,7 +30,6 @@ $bytes = [System.Text.Encoding]::ASCII.GetBytes($pair)
 $base64 = [System.Convert]::ToBase64String($bytes)
 $basicAuthValue = "Basic $base64"
 $headers = @{ Authorization = $basicAuthValue }
-
 $url = "https://advsec.dev.azure.com/{0}/{1}/_apis/alert/repositories/{2}/alerts?api-version=7.2-preview.1" -f $orgName, $project, $repositoryId
 
 $alerts = Invoke-WebRequest -Uri $url -Headers $headers -Method Get

--- a/src/gating/gating.ps1
+++ b/src/gating/gating.ps1
@@ -30,7 +30,8 @@ $bytes = [System.Text.Encoding]::ASCII.GetBytes($pair)
 $base64 = [System.Convert]::ToBase64String($bytes)
 $basicAuthValue = "Basic $base64"
 $headers = @{ Authorization = $basicAuthValue }
-$url = "https://advsec.dev.azure.com/{0}/{1}/_apis/AdvancedSecurity/Repositories/{2}/alerts?useDatabaseProvider=true" -f $orgName, $project, $repositoryId
+
+$url = "https://advsec.dev.azure.com/{0}/{1}/_apis/alert/repositories/{2}/alerts?api-version=7.2-preview.1" -f $orgName, $project, $repositoryId
 
 $alerts = Invoke-WebRequest -Uri $url -Headers $headers -Method Get
 if ($alerts.StatusCode -ne 200) {


### PR DESCRIPTION
This pull request includes a change to the `src/gating/gating.ps1` file. The change modifies the `$url` variable to point to a different API endpoint. This change is made to call a updated version of the API.