### PR TITLE
CI Gate - Use PWSH in sample

### DIFF
--- a/src/pr-gating/CIVerify.yml
+++ b/src/pr-gating/CIVerify.yml
@@ -45,5 +45,6 @@ steps:
   inputs:
     targetType: filePath
     filePath: CIGate.ps1
+    pwsh: true # Script requires PS7 (otherwise you will see syntax error - Unexpected token '?' )
   env:
     MAPPED_ADO_PAT: $(GATING_PAT)


### PR DESCRIPTION
This pull request includes a change to the `src/pr-gating/CIVerify.yml` file. The change involves adding a `pwsh: true` line under `inputs:`. This indicates that the script requires PowerShell 7, without which a syntax error may occur.