### PR TITLE
CodeQL Decorator - Publish task no longer required 🎉

### DIFF
--- a/src/extensions/codeql-autoinjection/decorator.yml
+++ b/src/extensions/codeql-autoinjection/decorator.yml
@@ -8,6 +8,3 @@ steps:
   - task: AdvancedSecurity-CodeQL-Analyze@1
     displayName: Perform CodeQL Analysis (Autoinjected)
     condition: eq(variables['AdvancedSecurity.CodeQL.Autoconfig'], 'true')
-  - task: AdvancedSecurity-Publish@1
-    displayName: Publish CodeQL Results (Autoinjected)
-    condition: eq(variables['AdvancedSecurity.CodeQL.Autoconfig'], 'true')


### PR DESCRIPTION
This pull request includes a change in the `src/extensions/codeql-autoinjection/decorator.yml` file that simplifies the `steps:` section. The tasks `AdvancedSecurity-Publish@1` for publishing CodeQL results have been removed, implying that the results will no longer be automatically published when the `AdvancedSecurity.CodeQL.Autoconfig` variable is set to `true`.