### PR TITLE
Add GHAzDO committer report script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,3 +95,6 @@ $RECYCLE.BIN/
 *.msm
 *.msp
 *.txz
+
+# Committer report
+src/committer-report/committer-report*.csv

--- a/src/committer-report/Get-CommitterReport.ps1
+++ b/src/committer-report/Get-CommitterReport.ps1
@@ -49,7 +49,7 @@ param(
 # -------------------------------------------------------------------
 # Configuration
 # -------------------------------------------------------------------
-$ApiTimeoutSec = 60
+$ApiTimeoutSec = 120
 
 # -------------------------------------------------------------------
 # Prerequisites (uncomment and run once if not already set up)
@@ -143,6 +143,9 @@ $orgs.value | Select-Object accountName, accountUri | Format-Table -AutoSize
 # Hashtable keyed by cuid (stable unique ID across Azure subscriptions) — tracks orgs and license status
 $committerMap = @{}
 
+# Track orgs where API calls failed (partial data)
+$partialDataOrgs = [System.Collections.Generic.List[string]]::new()
+
 # Helper to merge users into the committer map
 function Add-CommittersToMap {
     param($Users, $OrgName, $IsLicensed, $Plan)
@@ -201,7 +204,9 @@ foreach ($org in $orgs.value) {
         Add-CommittersToMap -Users $spEstUsers -OrgName $orgName -IsLicensed $false -Plan 'SecretProtection'
     }
     catch {
-        Write-Warning "  Estimate API skipped for '$orgName': $($_.Exception.Message)"
+        Write-Warning "  Estimate API failed for '$orgName': $($_.Exception.Message)"
+        Write-Warning "  Estimated committers for '$orgName' will be missing from the report."
+        $partialDataOrgs.Add($orgName) | Out-Null
     }
 
     # 6b - Org-level actual meter usage per plan (committers currently consuming a license)
@@ -308,6 +313,14 @@ Write-Host " COMMITTER REPORT SUMMARY" -ForegroundColor Yellow
 Write-Host "========================================" -ForegroundColor Yellow
 Write-Host "Total distinct committers across all orgs: $totalDistinct" -ForegroundColor Green
 
+if ($partialDataOrgs.Count -gt 0) {
+    Write-Host "`n⚠️  WARNING: Data is PARTIAL for the following org(s) due to API errors:" -ForegroundColor Red
+    foreach ($po in $partialDataOrgs) {
+        Write-Host "    - $po" -ForegroundColor Red
+    }
+    Write-Host "  Estimated (unlicensed) committers from these orgs may be missing from the report." -ForegroundColor Red
+}
+
 # -------------------------------------------------------------------
 # Step 8 - Report: Distinct count per org
 # -------------------------------------------------------------------
@@ -347,7 +360,9 @@ $report = $allCommitters |
         ($effectivePlans | Sort-Object) -join ', '
     }}, @{N='Organizations';E={$_.Orgs -join ', '}}
 
-$report | Format-Table -Property DisplayName, GHAzDOLicensed, Plans, Organizations -AutoSize -Wrap
+if (-not $CsvPath) {
+    $report | Format-Table -Property DisplayName, GHAzDOLicensed, Plans, Organizations -AutoSize -Wrap
+}
 
 # -------------------------------------------------------------------
 # Step 10 - Export to CSV if requested
@@ -364,4 +379,8 @@ if ($CsvPath) {
     }
     $sanitizedReport | Export-Csv -Path $CsvPath -NoTypeInformation -Encoding UTF8
     Write-Host "CSV exported to: $CsvPath" -ForegroundColor Green
+}
+else {
+    Write-Host "`nTip: Use -CsvPath to export the report to a file, e.g.:" -ForegroundColor DarkGray
+    Write-Host "  .\Get-CommitterReport.ps1 -CsvPath .\committer-report.csv" -ForegroundColor DarkGray
 }

--- a/src/committer-report/Get-CommitterReport.ps1
+++ b/src/committer-report/Get-CommitterReport.ps1
@@ -197,7 +197,11 @@ foreach ($org in $orgs.value) {
 
         # Deduplicate for count display
         $allCuids = @{}
-        ($csEstUsers + $spEstUsers) | ForEach-Object { $allCuids[$_.cuid] = $_ }
+        ($csEstUsers + $spEstUsers) | ForEach-Object {
+            if (-not [string]::IsNullOrWhiteSpace($_.cuid)) {
+                $allCuids[$_.cuid] = $_
+            }
+        }
 
         Write-Host "  Estimated (AdvSec OFF repos): $($allCuids.Count)" -ForegroundColor DarkGray
         Add-CommittersToMap -Users $csEstUsers -OrgName $orgName -IsLicensed $false -Plan 'CodeSecurity'
@@ -239,15 +243,20 @@ foreach ($org in $orgs.value) {
         }
     }
     catch {
-        # plan=all rejected — determine why
+        # plan=all rejected — determine why using HTTP status code
+        $statusCode = $null
+        if ($_.Exception.Response) {
+            $statusCode = [int]$_.Exception.Response.StatusCode
+        }
         $errorMsg = $_.Exception.Message
-        if ($errorMsg -match '404') {
+
+        if ($statusCode -eq 404) {
             # 404 on plan=all: In all observed cases, bundled orgs return 404 when no
             # plan has been purchased, while unbundled orgs return 400 "Invalid plan: All"
             # regardless of purchase state. So we treat 404 as bundled (no plan purchased).
             Write-Host "  Billing model: Bundled (AdvancedSecurity) — no plan purchased [plan=all → 404]" -ForegroundColor DarkGray
         }
-        elseif ($errorMsg -match 'Invalid plan|400') {
+        elseif ($statusCode -eq 400) {
             # 400 "Invalid plan: All" = org is unbundled, query each plan separately
             $unbundledResults = @{}
             foreach ($plan in @('codeSecurity', 'secretProtection')) {
@@ -258,12 +267,13 @@ foreach ($org in $orgs.value) {
                     $unbundledResults[$planLabel] = @{ Success = $true; Usage = $usage }
                 }
                 catch {
-                    $unbundledResults[$planLabel] = @{ Success = $false; Error = $_.Exception.Message }
+                    $perPlanStatus = if ($_.Exception.Response) { [int]$_.Exception.Response.StatusCode } else { $null }
+                    $unbundledResults[$planLabel] = @{ Success = $false; StatusCode = $perPlanStatus; Error = $_.Exception.Message }
                 }
             }
 
             # If both plans returned 404, neither is purchased — show a single message
-            $allNotPurchased = ($unbundledResults.Values | Where-Object { -not $_.Success -and $_.Error -match '404' }).Count -eq 2
+            $allNotPurchased = ($unbundledResults.Values | Where-Object { -not $_.Success -and $_.StatusCode -eq 404 }).Count -eq 2
             if ($allNotPurchased) {
                 Write-Host "  Billing model: Unbundled (CodeSecurity + SecretProtection) — no plans purchased [plan=all → 400]" -ForegroundColor DarkGray
             }
@@ -286,7 +296,7 @@ foreach ($org in $orgs.value) {
                         }
                     }
                     else {
-                        if ($result.Error -match '404') {
+                        if ($result.StatusCode -eq 404) {
                             Write-Host "  $planLabel not purchased" -ForegroundColor DarkGray
                         }
                         else {
@@ -297,7 +307,7 @@ foreach ($org in $orgs.value) {
             }
         }
         else {
-            Write-Host "  Meter usage unavailable: $errorMsg" -ForegroundColor DarkGray
+            Write-Host "  Meter usage unavailable ($statusCode): $errorMsg" -ForegroundColor DarkGray
         }
     }
 }
@@ -346,18 +356,24 @@ Write-Host "`n--- Committer Details ---" -ForegroundColor Yellow
 $report = $allCommitters |
     Sort-Object DisplayName |
     Select-Object DisplayName, UserPrincipalName, GHAzDOLicensed, @{N='Plans';E={
-        # Compute the effective plan per org, then deduplicate across orgs
-        $effectivePlans = [System.Collections.Generic.HashSet[string]]::new()
-        foreach ($orgEntry in $_.OrgPlans.GetEnumerator()) {
-            $orgPlanSet = $orgEntry.Value
-            if ($orgPlanSet.Contains('CodeSecurity') -and $orgPlanSet.Contains('SecretProtection')) {
-                $effectivePlans.Add('AdvancedSecurity') | Out-Null
-            }
-            else {
-                foreach ($p in $orgPlanSet) { $effectivePlans.Add($p) | Out-Null }
-            }
+        # If not licensed, no plan data is relevant
+        if (-not $_.GHAzDOLicensed -or -not $_.OrgPlans -or $_.OrgPlans.Count -eq 0) {
+            'N/A'
         }
-        ($effectivePlans | Sort-Object) -join ', '
+        else {
+            # Compute the effective plan per org, then deduplicate across orgs
+            $effectivePlans = [System.Collections.Generic.HashSet[string]]::new()
+            foreach ($orgEntry in $_.OrgPlans.GetEnumerator()) {
+                $orgPlanSet = $orgEntry.Value
+                if ($orgPlanSet.Contains('CodeSecurity') -and $orgPlanSet.Contains('SecretProtection')) {
+                    $effectivePlans.Add('AdvancedSecurity') | Out-Null
+                }
+                else {
+                    foreach ($p in $orgPlanSet) { $effectivePlans.Add($p) | Out-Null }
+                }
+            }
+            ($effectivePlans | Sort-Object) -join ', '
+        }
     }}, @{N='Organizations';E={$_.Orgs -join ', '}}
 
 if (-not $CsvPath) {

--- a/src/committer-report/Get-CommitterReport.ps1
+++ b/src/committer-report/Get-CommitterReport.ps1
@@ -1,0 +1,192 @@
+#Requires -Version 7.0
+
+<#
+.SYNOPSIS
+    Generates a GHAzDO (GitHub Advanced Security for Azure DevOps) committer report
+    across all accessible organizations.
+
+.DESCRIPTION
+    Enumerates all Azure DevOps organizations for the signed-in user, then for each
+    org queries the Advanced Security meter usage estimate API to identify active
+    committers. Produces:
+      - A distinct committer count across all orgs
+      - A distinct committer count per org
+      - A detailed list of committers with their org memberships and GHAzDO license status
+
+.NOTES
+    Prerequisites:
+      1. Install the Azure CLI   - https://learn.microsoft.com/en-us/cli/azure/install-azure-cli
+      2. Install the extension   - az extension add --name azure-devops
+      3. Sign in                 - az login
+#>
+
+# -------------------------------------------------------------------
+# Prerequisites (uncomment and run once if not already set up)
+# -------------------------------------------------------------------
+# az extension add --name azure-devops
+# az login
+
+# -------------------------------------------------------------------
+# Step 1 - Verify Azure CLI session
+# -------------------------------------------------------------------
+Write-Host "Checking Azure CLI login status..." -ForegroundColor Cyan
+
+$account = az account show 2>&1
+if ($LASTEXITCODE -ne 0) {
+    Write-Error "You are not logged in to Azure CLI. Please run 'az login' first."
+    exit 1
+}
+
+Write-Host "Logged in successfully." -ForegroundColor Green
+
+# -------------------------------------------------------------------
+# Step 2 - Acquire an access token for Azure DevOps
+# -------------------------------------------------------------------
+Write-Host "Acquiring access token for Azure DevOps..." -ForegroundColor Cyan
+
+$adoResource = "499b84ac-1321-427f-aa17-267ca6975798"
+$tokenJson = az account get-access-token --resource $adoResource 2>&1
+
+if ($LASTEXITCODE -ne 0) {
+    Write-Error "Failed to acquire access token. Response: $tokenJson"
+    exit 1
+}
+
+$accessToken = ($tokenJson | ConvertFrom-Json).accessToken
+$headers = @{ Authorization = "Bearer $accessToken" }
+Write-Host "Access token acquired." -ForegroundColor Green
+
+# -------------------------------------------------------------------
+# Step 3 - Get the signed-in user's VSSPS profile ID
+# -------------------------------------------------------------------
+Write-Host "Retrieving Azure DevOps profile..." -ForegroundColor Cyan
+
+$profile = Invoke-RestMethod -Uri "https://app.vssps.visualstudio.com/_apis/profile/profiles/me?api-version=7.1" -Headers $headers -Method Get
+$memberId = $profile.id
+
+if ([string]::IsNullOrWhiteSpace($memberId)) {
+    Write-Error "Failed to retrieve Azure DevOps profile ID."
+    exit 1
+}
+
+Write-Host "Member ID: $memberId" -ForegroundColor Green
+
+# -------------------------------------------------------------------
+# Step 4 - List Azure DevOps organizations via REST API
+# -------------------------------------------------------------------
+Write-Host "Fetching Azure DevOps organizations..." -ForegroundColor Cyan
+
+$url = "https://app.vssps.visualstudio.com/_apis/accounts?memberId=$memberId&api-version=7.1"
+$orgs = Invoke-RestMethod -Uri $url -Headers $headers -Method Get
+
+# -------------------------------------------------------------------
+# Step 5 - Display organizations
+# -------------------------------------------------------------------
+if ($orgs.count -eq 0) {
+    Write-Warning "No Azure DevOps organizations found for this account."
+    exit 0
+}
+
+Write-Host "`nFound $($orgs.count) organization(s):`n" -ForegroundColor Green
+$orgs.value | Select-Object accountName, accountUri | Format-Table -AutoSize
+
+# -------------------------------------------------------------------
+# Step 6 - For each org, get estimated committers via org-level API
+# -------------------------------------------------------------------
+
+# Hashtable keyed by committer identity — tracks orgs
+$committerMap = @{}
+
+foreach ($org in $orgs.value) {
+    $orgName = $org.accountName
+    Write-Host "Processing org: $orgName ..." -ForegroundColor Cyan
+
+    # Org-level meter usage estimate — all projects/repos in one call
+    try {
+        $estimateUrl = "https://advsec.dev.azure.com/$orgName/_apis/management/meterUsageEstimate/default?plan=all&api-version=7.2-preview.3"
+        $estimate = Invoke-RestMethod -Uri $estimateUrl -Headers $headers -Method Get -TimeoutSec 30
+
+        # Merge committers from both Code Security and Secret Protection plans
+        $allBilledUsers = @()
+        if ($estimate.codeSecurityMeterUsageEstimate.billedUsers) {
+            $allBilledUsers += $estimate.codeSecurityMeterUsageEstimate.billedUsers
+        }
+        if ($estimate.secretProtectionMeterUsageEstimate.billedUsers) {
+            $allBilledUsers += $estimate.secretProtectionMeterUsageEstimate.billedUsers
+        }
+
+        if ($allBilledUsers.Count -gt 0) {
+            # Deduplicate within the org by cuid
+            $seenCuids = @{}
+            $uniqueUsers = @()
+            foreach ($u in $allBilledUsers) {
+                if (-not $seenCuids.ContainsKey($u.cuid)) {
+                    $seenCuids[$u.cuid] = $true
+                    $uniqueUsers += $u
+                }
+            }
+
+            Write-Host "  Estimated committers: $($uniqueUsers.Count)" -ForegroundColor Green
+
+            foreach ($user in $uniqueUsers) {
+                $upn = $user.userIdentity.uniqueName
+                if ([string]::IsNullOrWhiteSpace($upn)) { $upn = $user.userIdentity.displayName }
+                if ([string]::IsNullOrWhiteSpace($upn)) { continue }
+
+                if (-not $committerMap.ContainsKey($upn)) {
+                    $committerMap[$upn] = [PSCustomObject]@{
+                        DisplayName       = $user.userIdentity.displayName
+                        UserPrincipalName = $user.userIdentity.uniqueName
+                        Orgs              = [System.Collections.Generic.HashSet[string]]::new()
+                    }
+                }
+
+                $committerMap[$upn].Orgs.Add($orgName) | Out-Null
+            }
+        }
+        else {
+            Write-Host "  Estimated committers: 0" -ForegroundColor DarkGray
+        }
+    }
+    catch {
+        Write-Warning "  Skipping org '$orgName' — unable to query: $($_.Exception.Message)"
+    }
+}
+
+# -------------------------------------------------------------------
+# Step 7 - Report: Distinct count across all orgs
+# -------------------------------------------------------------------
+$allCommitters = $committerMap.Values
+$totalDistinct = $allCommitters.Count
+
+Write-Host "`n========================================" -ForegroundColor Yellow
+Write-Host " COMMITTER REPORT SUMMARY" -ForegroundColor Yellow
+Write-Host "========================================" -ForegroundColor Yellow
+Write-Host "Total distinct committers across all orgs: $totalDistinct" -ForegroundColor Green
+
+# -------------------------------------------------------------------
+# Step 8 - Report: Distinct count per org
+# -------------------------------------------------------------------
+Write-Host "`n--- Committers Per Org ---" -ForegroundColor Yellow
+
+$orgCounts = @{}
+foreach ($c in $allCommitters) {
+    foreach ($o in $c.Orgs) {
+        if (-not $orgCounts.ContainsKey($o)) { $orgCounts[$o] = 0 }
+        $orgCounts[$o]++
+    }
+}
+
+$orgCounts.GetEnumerator() | Sort-Object Name | ForEach-Object {
+    Write-Host "  $($_.Key): $($_.Value) committer(s)" -ForegroundColor White
+}
+
+# -------------------------------------------------------------------
+# Step 9 - Report: Full committer list with org memberships
+# -------------------------------------------------------------------
+Write-Host "`n--- Committer Details ---" -ForegroundColor Yellow
+
+$allCommitters |
+    Sort-Object DisplayName |
+    Select-Object DisplayName, UserPrincipalName, @{N='Organizations';E={$_.Orgs -join ', '}} |
+    Format-Table -AutoSize -Wrap

--- a/src/committer-report/Get-CommitterReport.ps1
+++ b/src/committer-report/Get-CommitterReport.ps1
@@ -7,18 +7,51 @@
 
 .DESCRIPTION
     Enumerates all Azure DevOps organizations for the signed-in user, then for each
-    org queries the Advanced Security meter usage estimate API to identify active
-    committers. Produces:
+    org queries two org-level APIs:
+      - meterUsageEstimate: committers who would be billed if AdvSec were enabled on
+        remaining repos (repos where AdvSec is currently OFF)
+      - meterusage: committers who are currently consuming a GHAzDO license
+    Produces:
       - A distinct committer count across all orgs
       - A distinct committer count per org
-      - A detailed list of committers with their org memberships and GHAzDO license status
+      - A detailed list of all committers with their org memberships and a boolean
+        indicating whether they are currently consuming a GHAzDO license
+
+.PARAMETER CsvPath
+    Optional. Path to export the committer report as a CSV file.
+    If not specified, results are displayed in the console only.
+
+.EXAMPLE
+    .\Get-CommitterReport.ps1
+    Displays the committer report in the console.
+
+.EXAMPLE
+    .\Get-CommitterReport.ps1 -CsvPath .\committer-report.csv
+    Displays the report and exports it to a CSV file.
 
 .NOTES
     Prerequisites:
       1. Install the Azure CLI   - https://learn.microsoft.com/en-us/cli/azure/install-azure-cli
       2. Install the extension   - az extension add --name azure-devops
-      3. Sign in                 - az login
+      3. Sign in                 - az login --tenant <tenant_id> --allow-no-subscriptions
+
+
+    ex:
+    az devops logout
+    az logout
+    az login --tenant <tenant_id> --allow-no-subscriptions
+
 #>
+
+param(
+    [Parameter(Mandatory = $false)]
+    [string]$CsvPath
+)
+
+# -------------------------------------------------------------------
+# Configuration
+# -------------------------------------------------------------------
+$ApiTimeoutSec = 60
 
 # -------------------------------------------------------------------
 # Prerequisites (uncomment and run once if not already set up)
@@ -37,7 +70,10 @@ if ($LASTEXITCODE -ne 0) {
     exit 1
 }
 
+$accountInfo = $account | ConvertFrom-Json
+$tenantId = $accountInfo.tenantId
 Write-Host "Logged in successfully." -ForegroundColor Green
+Write-Host "Tenant ID: $tenantId" -ForegroundColor Green
 
 # -------------------------------------------------------------------
 # Step 2 - Acquire an access token for Azure DevOps
@@ -91,65 +127,104 @@ Write-Host "`nFound $($orgs.count) organization(s):`n" -ForegroundColor Green
 $orgs.value | Select-Object accountName, accountUri | Format-Table -AutoSize
 
 # -------------------------------------------------------------------
-# Step 6 - For each org, get estimated committers via org-level API
+# Step 6 - For each org, get estimated + actual committers via org-level APIs
 # -------------------------------------------------------------------
 
-# Hashtable keyed by committer identity — tracks orgs
+# Hashtable keyed by committer identity — tracks orgs and license status
 $committerMap = @{}
+
+# Helper to merge users into the committer map
+function Add-CommittersToMap {
+    param($Users, $OrgName, $IsLicensed, $Plan)
+
+    foreach ($user in $Users) {
+        $upn = $user.userIdentity.uniqueName
+        if ([string]::IsNullOrWhiteSpace($upn)) { $upn = $user.userIdentity.displayName }
+        if ([string]::IsNullOrWhiteSpace($upn)) { continue }
+
+        if (-not $committerMap.ContainsKey($upn)) {
+            $committerMap[$upn] = [PSCustomObject]@{
+                DisplayName       = $user.userIdentity.displayName
+                UserPrincipalName = $user.userIdentity.uniqueName
+                Orgs              = [System.Collections.Generic.HashSet[string]]::new()
+                GHAzDOLicensed    = $false
+                OrgPlans          = @{}  # org name -> HashSet of plan labels
+            }
+        }
+
+        $committerMap[$upn].Orgs.Add($OrgName) | Out-Null
+        if ($IsLicensed) {
+            $committerMap[$upn].GHAzDOLicensed = $true
+            if ($Plan) {
+                if (-not $committerMap[$upn].OrgPlans.ContainsKey($OrgName)) {
+                    $committerMap[$upn].OrgPlans[$OrgName] = [System.Collections.Generic.HashSet[string]]::new()
+                }
+                $committerMap[$upn].OrgPlans[$OrgName].Add($Plan) | Out-Null
+            }
+        }
+    }
+}
 
 foreach ($org in $orgs.value) {
     $orgName = $org.accountName
     Write-Host "Processing org: $orgName ..." -ForegroundColor Cyan
 
-    # Org-level meter usage estimate — all projects/repos in one call
+    # 6a - Org-level meter usage estimate (committers for repos where AdvSec is OFF)
     try {
         $estimateUrl = "https://advsec.dev.azure.com/$orgName/_apis/management/meterUsageEstimate/default?plan=all&api-version=7.2-preview.3"
-        $estimate = Invoke-RestMethod -Uri $estimateUrl -Headers $headers -Method Get -TimeoutSec 30
+        $estimate = Invoke-RestMethod -Uri $estimateUrl -Headers $headers -Method Get -TimeoutSec $ApiTimeoutSec
 
-        # Merge committers from both Code Security and Secret Protection plans
-        $allBilledUsers = @()
+        $csEstUsers = @()
+        $spEstUsers = @()
         if ($estimate.codeSecurityMeterUsageEstimate.billedUsers) {
-            $allBilledUsers += $estimate.codeSecurityMeterUsageEstimate.billedUsers
+            $csEstUsers = $estimate.codeSecurityMeterUsageEstimate.billedUsers
         }
         if ($estimate.secretProtectionMeterUsageEstimate.billedUsers) {
-            $allBilledUsers += $estimate.secretProtectionMeterUsageEstimate.billedUsers
+            $spEstUsers = $estimate.secretProtectionMeterUsageEstimate.billedUsers
         }
 
-        if ($allBilledUsers.Count -gt 0) {
-            # Deduplicate within the org by cuid
-            $seenCuids = @{}
-            $uniqueUsers = @()
-            foreach ($u in $allBilledUsers) {
-                if (-not $seenCuids.ContainsKey($u.cuid)) {
-                    $seenCuids[$u.cuid] = $true
-                    $uniqueUsers += $u
-                }
-            }
+        # Deduplicate for count display
+        $allCuids = @{}
+        ($csEstUsers + $spEstUsers) | ForEach-Object { $allCuids[$_.cuid] = $_ }
 
-            Write-Host "  Estimated committers: $($uniqueUsers.Count)" -ForegroundColor Green
-
-            foreach ($user in $uniqueUsers) {
-                $upn = $user.userIdentity.uniqueName
-                if ([string]::IsNullOrWhiteSpace($upn)) { $upn = $user.userIdentity.displayName }
-                if ([string]::IsNullOrWhiteSpace($upn)) { continue }
-
-                if (-not $committerMap.ContainsKey($upn)) {
-                    $committerMap[$upn] = [PSCustomObject]@{
-                        DisplayName       = $user.userIdentity.displayName
-                        UserPrincipalName = $user.userIdentity.uniqueName
-                        Orgs              = [System.Collections.Generic.HashSet[string]]::new()
-                    }
-                }
-
-                $committerMap[$upn].Orgs.Add($orgName) | Out-Null
-            }
-        }
-        else {
-            Write-Host "  Estimated committers: 0" -ForegroundColor DarkGray
-        }
+        Write-Host "  Estimated (AdvSec OFF repos): $($allCuids.Count)" -ForegroundColor DarkGray
+        Add-CommittersToMap -Users $csEstUsers -OrgName $orgName -IsLicensed $false -Plan 'CodeSecurity'
+        Add-CommittersToMap -Users $spEstUsers -OrgName $orgName -IsLicensed $false -Plan 'SecretProtection'
     }
     catch {
-        Write-Warning "  Skipping org '$orgName' — unable to query: $($_.Exception.Message)"
+        Write-Warning "  Estimate API skipped for '$orgName': $($_.Exception.Message)"
+    }
+
+    # 6b - Org-level actual meter usage per plan (committers currently consuming a license)
+    # NOTE: The API does not expose whether an org uses a bundled (AdvancedSecurity) or
+    # unbundled (separate CodeSecurity / SecretProtection) billing model. For bundled
+    # orgs the API simply duplicates the same committers into both plan responses.
+    # We report each plan's enabled state and committer count as-is without inferring
+    # the billing model.
+    foreach ($plan in @('codeSecurity', 'secretProtection')) {
+        $planLabel = if ($plan -eq 'codeSecurity') { 'CodeSecurity' } else { 'SecretProtection' }
+        try {
+            $usageUrl = "https://advsec.dev.azure.com/$orgName/_apis/management/meterusage/default?plan=$plan&api-version=7.2-preview.3"
+            $usage = Invoke-RestMethod -Uri $usageUrl -Headers $headers -Method Get -TimeoutSec $ApiTimeoutSec
+
+            $isPlanEnabled = $usage.isPlanEnabled
+
+            $billedUsers = @()
+            if ($usage.billedUsers.billedUsers) {
+                $billedUsers = $usage.billedUsers.billedUsers
+            }
+
+            if ($isPlanEnabled) {
+                Write-Host "  Licensed ($planLabel):$((' ' * (20 - $planLabel.Length)))$($billedUsers.Count)" -ForegroundColor Green
+                Add-CommittersToMap -Users $billedUsers -OrgName $orgName -IsLicensed $true -Plan $planLabel
+            }
+            else {
+                Write-Host "  $planLabel plan not enabled" -ForegroundColor DarkGray
+            }
+        }
+        catch {
+            Write-Host "  $planLabel meter usage unavailable: $($_.Exception.Message)" -ForegroundColor DarkGray
+        }
     }
 }
 
@@ -186,7 +261,29 @@ $orgCounts.GetEnumerator() | Sort-Object Name | ForEach-Object {
 # -------------------------------------------------------------------
 Write-Host "`n--- Committer Details ---" -ForegroundColor Yellow
 
-$allCommitters |
+$report = $allCommitters |
     Sort-Object DisplayName |
-    Select-Object DisplayName, UserPrincipalName, @{N='Organizations';E={$_.Orgs -join ', '}} |
-    Format-Table -AutoSize -Wrap
+    Select-Object DisplayName, UserPrincipalName, GHAzDOLicensed, @{N='Plans';E={
+        # Compute the effective plan per org, then deduplicate across orgs
+        $effectivePlans = [System.Collections.Generic.HashSet[string]]::new()
+        foreach ($orgEntry in $_.OrgPlans.GetEnumerator()) {
+            $orgPlanSet = $orgEntry.Value
+            if ($orgPlanSet.Contains('CodeSecurity') -and $orgPlanSet.Contains('SecretProtection')) {
+                $effectivePlans.Add('AdvancedSecurity') | Out-Null
+            }
+            else {
+                foreach ($p in $orgPlanSet) { $effectivePlans.Add($p) | Out-Null }
+            }
+        }
+        ($effectivePlans | Sort-Object) -join ', '
+    }}, @{N='Organizations';E={$_.Orgs -join ', '}}
+
+$report | Format-Table -Property DisplayName, GHAzDOLicensed, Plans, Organizations -AutoSize -Wrap
+
+# -------------------------------------------------------------------
+# Step 10 - Export to CSV if requested
+# -------------------------------------------------------------------
+if ($CsvPath) {
+    $report | Export-Csv -Path $CsvPath -NoTypeInformation -Encoding UTF8
+    Write-Host "CSV exported to: $CsvPath" -ForegroundColor Green
+}

--- a/src/committer-report/Get-CommitterReport.ps1
+++ b/src/committer-report/Get-CommitterReport.ps1
@@ -224,7 +224,7 @@ foreach ($org in $orgs.value) {
             $billedUsers = $allUsage.billedUsers.billedUsers
         }
 
-        Write-Host "  Billing model: Bundled (AdvancedSecurity)" -ForegroundColor Cyan
+        Write-Host "  Billing model: Bundled (AdvancedSecurity) [plan=all → 200]" -ForegroundColor Cyan
         if ($allUsage.isPlanEnabled) {
             Write-Host "  Licensed (AdvancedSecurity): $($billedUsers.Count)" -ForegroundColor Green
             Add-CommittersToMap -Users $billedUsers -OrgName $orgName -IsLicensed $true -Plan 'AdvancedSecurity'
@@ -234,31 +234,60 @@ foreach ($org in $orgs.value) {
         }
     }
     catch {
-        # plan=all rejected — org is unbundled, query each plan separately
+        # plan=all rejected — determine why
         $errorMsg = $_.Exception.Message
-        if ($errorMsg -match 'Invalid plan|400') {
-            Write-Host "  Billing model: Unbundled (CodeSecurity + SecretProtection)" -ForegroundColor Cyan
+        if ($errorMsg -match '404') {
+            # 404 on plan=all: In all observed cases, bundled orgs return 404 when no
+            # plan has been purchased, while unbundled orgs return 400 "Invalid plan: All"
+            # regardless of purchase state. So we treat 404 as bundled (no plan purchased).
+            Write-Host "  Billing model: Bundled (AdvancedSecurity) — no plan purchased [plan=all → 404]" -ForegroundColor DarkGray
+        }
+        elseif ($errorMsg -match 'Invalid plan|400') {
+            # 400 "Invalid plan: All" = org is unbundled, query each plan separately
+            $unbundledResults = @{}
             foreach ($plan in @('codeSecurity', 'secretProtection')) {
                 $planLabel = if ($plan -eq 'codeSecurity') { 'CodeSecurity' } else { 'SecretProtection' }
                 try {
                     $usageUrl = "https://advsec.dev.azure.com/$orgName/_apis/management/meterusage/default?plan=$plan&api-version=7.2-preview.3"
                     $usage = Invoke-RestMethod -Uri $usageUrl -Headers $headers -Method Get -TimeoutSec $ApiTimeoutSec
-
-                    $billedUsers = @()
-                    if ($usage.billedUsers.billedUsers) {
-                        $billedUsers = $usage.billedUsers.billedUsers
-                    }
-
-                    if ($usage.isPlanEnabled) {
-                        Write-Host "  Licensed ($planLabel):$((' ' * (20 - $planLabel.Length)))$($billedUsers.Count)" -ForegroundColor Green
-                        Add-CommittersToMap -Users $billedUsers -OrgName $orgName -IsLicensed $true -Plan $planLabel
-                    }
-                    else {
-                        Write-Host "  $planLabel plan not enabled" -ForegroundColor DarkGray
-                    }
+                    $unbundledResults[$planLabel] = @{ Success = $true; Usage = $usage }
                 }
                 catch {
-                    Write-Host "  $planLabel meter usage unavailable: $($_.Exception.Message)" -ForegroundColor DarkGray
+                    $unbundledResults[$planLabel] = @{ Success = $false; Error = $_.Exception.Message }
+                }
+            }
+
+            # If both plans returned 404, neither is purchased — show a single message
+            $allNotPurchased = ($unbundledResults.Values | Where-Object { -not $_.Success -and $_.Error -match '404' }).Count -eq 2
+            if ($allNotPurchased) {
+                Write-Host "  Billing model: Unbundled (CodeSecurity + SecretProtection) — no plans purchased [plan=all → 400]" -ForegroundColor DarkGray
+            }
+            else {
+                Write-Host "  Billing model: Unbundled (CodeSecurity + SecretProtection) [plan=all → 400]" -ForegroundColor Cyan
+                foreach ($planLabel in @('CodeSecurity', 'SecretProtection')) {
+                    $result = $unbundledResults[$planLabel]
+                    if ($result.Success) {
+                        $billedUsers = @()
+                        if ($result.Usage.billedUsers.billedUsers) {
+                            $billedUsers = $result.Usage.billedUsers.billedUsers
+                        }
+
+                        if ($result.Usage.isPlanEnabled) {
+                            Write-Host "  Licensed ($planLabel):$((' ' * (20 - $planLabel.Length)))$($billedUsers.Count)" -ForegroundColor Green
+                            Add-CommittersToMap -Users $billedUsers -OrgName $orgName -IsLicensed $true -Plan $planLabel
+                        }
+                        else {
+                            Write-Host "  $planLabel plan not enabled" -ForegroundColor DarkGray
+                        }
+                    }
+                    else {
+                        if ($result.Error -match '404') {
+                            Write-Host "  $planLabel not purchased" -ForegroundColor DarkGray
+                        }
+                        else {
+                            Write-Host "  $planLabel meter usage unavailable: $($result.Error)" -ForegroundColor DarkGray
+                        }
+                    }
                 }
             }
         }

--- a/src/committer-report/Get-CommitterReport.ps1
+++ b/src/committer-report/Get-CommitterReport.ps1
@@ -284,6 +284,15 @@ $report | Format-Table -Property DisplayName, GHAzDOLicensed, Plans, Organizatio
 # Step 10 - Export to CSV if requested
 # -------------------------------------------------------------------
 if ($CsvPath) {
-    $report | Export-Csv -Path $CsvPath -NoTypeInformation -Encoding UTF8
+    $sanitizedReport = $report | ForEach-Object {
+        $sanitizedRow = $_.PSObject.Copy()
+        foreach ($property in $sanitizedRow.PSObject.Properties) {
+            if ($property.Value -is [string] -and $property.Value -match '^[=+\-@]') {
+                $property.Value = "'$($property.Value)"
+            }
+        }
+        $sanitizedRow
+    }
+    $sanitizedReport | Export-Csv -Path $CsvPath -NoTypeInformation -Encoding UTF8
     Write-Host "CSV exported to: $CsvPath" -ForegroundColor Green
 }

--- a/src/committer-report/Get-CommitterReport.ps1
+++ b/src/committer-report/Get-CommitterReport.ps1
@@ -32,12 +32,10 @@
 .NOTES
     Prerequisites:
       1. Install the Azure CLI   - https://learn.microsoft.com/en-us/cli/azure/install-azure-cli
-      2. Install the extension   - az extension add --name azure-devops
-      3. Sign in                 - az login --tenant <tenant_id> --allow-no-subscriptions
+      2. Sign in                 - az login --tenant <tenant_id> --allow-no-subscriptions
 
 
     ex:
-    az devops logout
     az logout
     az login --tenant <tenant_id> --allow-no-subscriptions
 
@@ -56,7 +54,6 @@ $ApiTimeoutSec = 60
 # -------------------------------------------------------------------
 # Prerequisites (uncomment and run once if not already set up)
 # -------------------------------------------------------------------
-# az extension add --name azure-devops
 # az login
 
 # -------------------------------------------------------------------
@@ -64,7 +61,7 @@ $ApiTimeoutSec = 60
 # -------------------------------------------------------------------
 Write-Host "Checking Azure CLI login status..." -ForegroundColor Cyan
 
-$account = az account show 2>&1
+$account = az account show --output json 2>&1
 if ($LASTEXITCODE -ne 0) {
     Write-Error "You are not logged in to Azure CLI. Please run 'az login' first."
     exit 1
@@ -81,7 +78,7 @@ Write-Host "Tenant ID: $tenantId" -ForegroundColor Green
 Write-Host "Acquiring access token for Azure DevOps..." -ForegroundColor Cyan
 
 $adoResource = "499b84ac-1321-427f-aa17-267ca6975798"
-$tokenJson = az account get-access-token --resource $adoResource 2>&1
+$tokenJson = az account get-access-token --resource $adoResource --output json 2>&1
 
 if ($LASTEXITCODE -ne 0) {
     Write-Error "Failed to acquire access token. Response: $tokenJson"
@@ -97,7 +94,14 @@ Write-Host "Access token acquired." -ForegroundColor Green
 # -------------------------------------------------------------------
 Write-Host "Retrieving Azure DevOps profile..." -ForegroundColor Cyan
 
-$profile = Invoke-RestMethod -Uri "https://app.vssps.visualstudio.com/_apis/profile/profiles/me?api-version=7.1" -Headers $headers -Method Get
+try {
+    $profile = Invoke-RestMethod -Uri "https://app.vssps.visualstudio.com/_apis/profile/profiles/me?api-version=7.1" -Headers $headers -Method Get
+}
+catch {
+    Write-Error "Failed to retrieve Azure DevOps profile. Verify your token has the required scopes. Error: $($_.Exception.Message)"
+    exit 1
+}
+
 $memberId = $profile.id
 
 if ([string]::IsNullOrWhiteSpace($memberId)) {
@@ -112,8 +116,14 @@ Write-Host "Member ID: $memberId" -ForegroundColor Green
 # -------------------------------------------------------------------
 Write-Host "Fetching Azure DevOps organizations..." -ForegroundColor Cyan
 
-$url = "https://app.vssps.visualstudio.com/_apis/accounts?memberId=$memberId&api-version=7.1"
-$orgs = Invoke-RestMethod -Uri $url -Headers $headers -Method Get
+try {
+    $url = "https://app.vssps.visualstudio.com/_apis/accounts?memberId=$memberId&api-version=7.1"
+    $orgs = Invoke-RestMethod -Uri $url -Headers $headers -Method Get
+}
+catch {
+    Write-Error "Failed to fetch Azure DevOps organizations. Error: $($_.Exception.Message)"
+    exit 1
+}
 
 # -------------------------------------------------------------------
 # Step 5 - Display organizations
@@ -130,7 +140,7 @@ $orgs.value | Select-Object accountName, accountUri | Format-Table -AutoSize
 # Step 6 - For each org, get estimated + actual committers via org-level APIs
 # -------------------------------------------------------------------
 
-# Hashtable keyed by committer identity — tracks orgs and license status
+# Hashtable keyed by cuid (stable unique ID across Azure subscriptions) — tracks orgs and license status
 $committerMap = @{}
 
 # Helper to merge users into the committer map
@@ -138,12 +148,11 @@ function Add-CommittersToMap {
     param($Users, $OrgName, $IsLicensed, $Plan)
 
     foreach ($user in $Users) {
-        $upn = $user.userIdentity.uniqueName
-        if ([string]::IsNullOrWhiteSpace($upn)) { $upn = $user.userIdentity.displayName }
-        if ([string]::IsNullOrWhiteSpace($upn)) { continue }
+        $key = $user.cuid
+        if ([string]::IsNullOrWhiteSpace($key)) { continue }
 
-        if (-not $committerMap.ContainsKey($upn)) {
-            $committerMap[$upn] = [PSCustomObject]@{
+        if (-not $committerMap.ContainsKey($key)) {
+            $committerMap[$key] = [PSCustomObject]@{
                 DisplayName       = $user.userIdentity.displayName
                 UserPrincipalName = $user.userIdentity.uniqueName
                 Orgs              = [System.Collections.Generic.HashSet[string]]::new()
@@ -152,14 +161,14 @@ function Add-CommittersToMap {
             }
         }
 
-        $committerMap[$upn].Orgs.Add($OrgName) | Out-Null
+        $committerMap[$key].Orgs.Add($OrgName) | Out-Null
         if ($IsLicensed) {
-            $committerMap[$upn].GHAzDOLicensed = $true
+            $committerMap[$key].GHAzDOLicensed = $true
             if ($Plan) {
-                if (-not $committerMap[$upn].OrgPlans.ContainsKey($OrgName)) {
-                    $committerMap[$upn].OrgPlans[$OrgName] = [System.Collections.Generic.HashSet[string]]::new()
+                if (-not $committerMap[$key].OrgPlans.ContainsKey($OrgName)) {
+                    $committerMap[$key].OrgPlans[$OrgName] = [System.Collections.Generic.HashSet[string]]::new()
                 }
-                $committerMap[$upn].OrgPlans[$OrgName].Add($Plan) | Out-Null
+                $committerMap[$key].OrgPlans[$OrgName].Add($Plan) | Out-Null
             }
         }
     }
@@ -196,34 +205,65 @@ foreach ($org in $orgs.value) {
     }
 
     # 6b - Org-level actual meter usage per plan (committers currently consuming a license)
-    # NOTE: The API does not expose whether an org uses a bundled (AdvancedSecurity) or
-    # unbundled (separate CodeSecurity / SecretProtection) billing model. For bundled
-    # orgs the API simply duplicates the same committers into both plan responses.
-    # We report each plan's enabled state and committer count as-is without inferring
-    # the billing model.
-    foreach ($plan in @('codeSecurity', 'secretProtection')) {
-        $planLabel = if ($plan -eq 'codeSecurity') { 'CodeSecurity' } else { 'SecretProtection' }
-        try {
-            $usageUrl = "https://advsec.dev.azure.com/$orgName/_apis/management/meterusage/default?plan=$plan&api-version=7.2-preview.3"
-            $usage = Invoke-RestMethod -Uri $usageUrl -Headers $headers -Method Get -TimeoutSec $ApiTimeoutSec
+    # ⚠️ WARNING: UNDOCUMENTED BEHAVIOR — FRAGILE DETECTION ⚠️
+    # The billing model (bundled vs unbundled) is not exposed by any documented API field.
+    # This detection relies on an undocumented behavioral difference found by trial and error:
+    #   - Bundled orgs accept plan=all on the meter usage API and return a unified response.
+    #   - Unbundled orgs reject plan=all with a 400 "Invalid plan: All" error.
+    # This behavior is not guaranteed by Microsoft and may change without notice.
+    # If this detection breaks, fall back to querying each plan separately and remove
+    # the bundled/unbundled distinction from the output.
+    $isBundled = $false
+    try {
+        $allUrl = "https://advsec.dev.azure.com/$orgName/_apis/management/meterusage/default?plan=all&api-version=7.2-preview.3"
+        $allUsage = Invoke-RestMethod -Uri $allUrl -Headers $headers -Method Get -TimeoutSec $ApiTimeoutSec
+        $isBundled = $true
 
-            $isPlanEnabled = $usage.isPlanEnabled
+        $billedUsers = @()
+        if ($allUsage.billedUsers.billedUsers) {
+            $billedUsers = $allUsage.billedUsers.billedUsers
+        }
 
-            $billedUsers = @()
-            if ($usage.billedUsers.billedUsers) {
-                $billedUsers = $usage.billedUsers.billedUsers
-            }
+        Write-Host "  Billing model: Bundled (AdvancedSecurity)" -ForegroundColor Cyan
+        if ($allUsage.isPlanEnabled) {
+            Write-Host "  Licensed (AdvancedSecurity): $($billedUsers.Count)" -ForegroundColor Green
+            Add-CommittersToMap -Users $billedUsers -OrgName $orgName -IsLicensed $true -Plan 'AdvancedSecurity'
+        }
+        else {
+            Write-Host "  AdvancedSecurity plan not enabled" -ForegroundColor DarkGray
+        }
+    }
+    catch {
+        # plan=all rejected — org is unbundled, query each plan separately
+        $errorMsg = $_.Exception.Message
+        if ($errorMsg -match 'Invalid plan|400') {
+            Write-Host "  Billing model: Unbundled (CodeSecurity + SecretProtection)" -ForegroundColor Cyan
+            foreach ($plan in @('codeSecurity', 'secretProtection')) {
+                $planLabel = if ($plan -eq 'codeSecurity') { 'CodeSecurity' } else { 'SecretProtection' }
+                try {
+                    $usageUrl = "https://advsec.dev.azure.com/$orgName/_apis/management/meterusage/default?plan=$plan&api-version=7.2-preview.3"
+                    $usage = Invoke-RestMethod -Uri $usageUrl -Headers $headers -Method Get -TimeoutSec $ApiTimeoutSec
 
-            if ($isPlanEnabled) {
-                Write-Host "  Licensed ($planLabel):$((' ' * (20 - $planLabel.Length)))$($billedUsers.Count)" -ForegroundColor Green
-                Add-CommittersToMap -Users $billedUsers -OrgName $orgName -IsLicensed $true -Plan $planLabel
-            }
-            else {
-                Write-Host "  $planLabel plan not enabled" -ForegroundColor DarkGray
+                    $billedUsers = @()
+                    if ($usage.billedUsers.billedUsers) {
+                        $billedUsers = $usage.billedUsers.billedUsers
+                    }
+
+                    if ($usage.isPlanEnabled) {
+                        Write-Host "  Licensed ($planLabel):$((' ' * (20 - $planLabel.Length)))$($billedUsers.Count)" -ForegroundColor Green
+                        Add-CommittersToMap -Users $billedUsers -OrgName $orgName -IsLicensed $true -Plan $planLabel
+                    }
+                    else {
+                        Write-Host "  $planLabel plan not enabled" -ForegroundColor DarkGray
+                    }
+                }
+                catch {
+                    Write-Host "  $planLabel meter usage unavailable: $($_.Exception.Message)" -ForegroundColor DarkGray
+                }
             }
         }
-        catch {
-            Write-Host "  $planLabel meter usage unavailable: $($_.Exception.Message)" -ForegroundColor DarkGray
+        else {
+            Write-Host "  Meter usage unavailable: $errorMsg" -ForegroundColor DarkGray
         }
     }
 }

--- a/src/committer-report/README.md
+++ b/src/committer-report/README.md
@@ -46,10 +46,10 @@ The report includes the following columns:
 
 ## Limitations
 
-**Bundled vs. unbundled plan detection:** The Azure DevOps Advanced Security APIs do not expose whether an organization uses a bundled (`AdvancedSecurity`) or unbundled (separate `CodeSecurity` / `SecretProtection`) billing model. For bundled orgs, the API simply duplicates the same committers into both the `codeSecurity` and `secretProtection` plan responses. This means:
+**Bundled vs. unbundled plan detection:** The Azure DevOps Advanced Security APIs do not expose a documented, supported way to tell whether an organization uses a bundled (`AdvancedSecurity`) or unbundled (separate `CodeSecurity` / `SecretProtection`) billing model. For bundled orgs, the API simply duplicates the same committers into both the `codeSecurity` and `secretProtection` plan responses. This means:
 
 - A bundled org with both plans active looks **identical** to an unbundled org with both plans active
-- The script reports `AdvancedSecurity` whenever both plans return data for an org, regardless of the actual billing model
-- There is no API field or endpoint to determine the true billing model
+- The script reports an **effective** `AdvancedSecurity` plan whenever both per-plan responses contain users for an org, regardless of the actual billing SKU or billing model
+- There is no reliable, documented API field or endpoint that definitively reports the true billing model
 
-If a committer spans multiple orgs with different billing configurations, the **Plans** column will list the distinct effective plans across all their orgs (e.g., `AdvancedSecurity, CodeSecurity`).
+The script also prints a `Billing model: Bundled/Unbundled` line based on an **undocumented heuristic** that inspects `plan=all` behavior. This is a best-effort guess only, may be incorrect, and may stop working if the underlying API behavior changes. The **Plans** column in the report continues to reflect an *effective plan* view (for example, `AdvancedSecurity` when both plan responses contain users), and **must not** be interpreted as an authoritative billing SKU from Azure DevOps billing systems.

--- a/src/committer-report/README.md
+++ b/src/committer-report/README.md
@@ -13,11 +13,7 @@ Generates a committer report for GitHub Advanced Security for Azure DevOps (GHAz
 ## Prerequisites
 
 1. Install the [Azure CLI](https://learn.microsoft.com/en-us/cli/azure/install-azure-cli)
-2. Install the Azure DevOps extension:
-   ```powershell
-   az extension add --name azure-devops
-   ```
-3. Sign in to the tenant that contains your Azure DevOps organizations:
+2. Sign in to the tenant that contains your Azure DevOps organizations:
    ```powershell
    az login --tenant <tenant_id> --allow-no-subscriptions
    ```

--- a/src/committer-report/README.md
+++ b/src/committer-report/README.md
@@ -1,0 +1,59 @@
+# GHAzDO Committer Report
+
+Generates a committer report for GitHub Advanced Security for Azure DevOps (GHAzDO) across all accessible organizations for the signed-in user.
+
+## What it does
+
+- Enumerates all Azure DevOps organizations for your account
+- Queries **estimated** committers (repos where AdvSec is currently OFF)
+- Queries **licensed** committers (currently consuming a GHAzDO license) per plan (CodeSecurity / SecretProtection)
+- Produces a deduplicated committer list with org memberships, license status, and plan details
+- Optionally exports results to CSV
+
+## Prerequisites
+
+1. Install the [Azure CLI](https://learn.microsoft.com/en-us/cli/azure/install-azure-cli)
+2. Install the Azure DevOps extension:
+   ```powershell
+   az extension add --name azure-devops
+   ```
+3. Sign in to the tenant that contains your Azure DevOps organizations:
+   ```powershell
+   az login --tenant <tenant_id> --allow-no-subscriptions
+   ```
+
+> **Note:** The script discovers organizations based on the signed-in user's tenant. If you have orgs across multiple tenants, run the script separately for each tenant after logging in with `az login --tenant <tenant_id> --allow-no-subscriptions`.
+
+## Usage
+
+Requires **PowerShell 7+**.
+
+```powershell
+# Display report in the console only
+.\Get-CommitterReport.ps1
+
+# Export report to CSV (recommended)
+.\Get-CommitterReport.ps1 -CsvPath .\committer-report.csv
+```
+
+## Output
+
+The report includes the following columns:
+
+| Column | Description |
+|---|---|
+| **DisplayName** | The committer's display name |
+| **UserPrincipalName** | The committer's UPN or identity |
+| **GHAzDOLicensed** | `True` if currently consuming a license, `False` if estimated only |
+| **Plans** | Active plan(s): `AdvancedSecurity`, `CodeSecurity`, `SecretProtection`, or a combination |
+| **Organizations** | Comma-separated list of orgs the committer belongs to |
+
+## Limitations
+
+**Bundled vs. unbundled plan detection:** The Azure DevOps Advanced Security APIs do not expose whether an organization uses a bundled (`AdvancedSecurity`) or unbundled (separate `CodeSecurity` / `SecretProtection`) billing model. For bundled orgs, the API simply duplicates the same committers into both the `codeSecurity` and `secretProtection` plan responses. This means:
+
+- A bundled org with both plans active looks **identical** to an unbundled org with both plans active
+- The script reports `AdvancedSecurity` whenever both plans return data for an org, regardless of the actual billing model
+- There is no API field or endpoint to determine the true billing model
+
+If a committer spans multiple orgs with different billing configurations, the **Plans** column will list the distinct effective plans across all their orgs (e.g., `AdvancedSecurity, CodeSecurity`).


### PR DESCRIPTION
Enumerates all Azure DevOps orgs for the signed-in user and queries the org-level meter usage estimate API to produce:
- Distinct committer count across all orgs
- Per-org committer counts
- Detailed committer list with org memberships

TODO
- [ ] Test on an unbundles split sku org (need to wait till 3/19 so my billing kicks in 😄 )


To test:
- view instructions: https://github.com/microsoft/GHAzDO-Resources/blob/committer-count/src/committer-report/README.md
- run this pwsh script: [https://raw.githubusercontent.com/microsoft/GHAzDO-Resources/refs/heads/committer-count/src/committer-report/Get-CommitterReport.ps1](https://raw.githubusercontent.com/microsoft/GHAzDO-Resources/refs/heads/committer-count/src/committer-report/Get-CommitterReport.ps1)


