### PR TITLE
Add GHAzDO to Nucleus FlexConnect integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ This project is a series of scripts and other resources for demonstrating and ac
 Security for Azure DevOps. These scripts are primarily for demonstration purposes, and should not be construed as part of
 the GHAS on ADO product.
 
+## Resources
+
+- [Export GHAzDO alerts to Nucleus using FlexConnect](./src/nucleus/README.md)
+
 ## Contributing
 
 This project welcomes contributions and suggestions.  Most contributions require you to agree to a

--- a/src/nucleus/GHAzDONucleus.psm1
+++ b/src/nucleus/GHAzDONucleus.psm1
@@ -1,0 +1,931 @@
+Set-StrictMode -Version Latest
+
+function Get-PropertyValue {
+    param(
+        [AllowNull()]
+        [object]$InputObject,
+
+        [Parameter(Mandatory)]
+        [string[]]$PropertyPath
+    )
+
+    $value = $InputObject
+    foreach ($propertyName in $PropertyPath) {
+        if ($null -eq $value) {
+            return $null
+        }
+
+        $property = $value.PSObject.Properties[$propertyName]
+        if ($null -eq $property) {
+            return $null
+        }
+        $value = $property.Value
+    }
+
+    return $value
+}
+
+function ConvertTo-ConstrainedAscii {
+    param(
+        [AllowNull()]
+        [object]$Value,
+
+        [int]$MaximumLength = 0
+    )
+
+    if ($null -eq $Value) {
+        return $null
+    }
+
+    $result = ([string]$Value) -replace '[^\x20-\x7E]', '?'
+    if ($MaximumLength -gt 0 -and $result.Length -gt $MaximumLength) {
+        return $result.Substring(0, $MaximumLength)
+    }
+
+    return $result
+}
+
+function Get-AdoAuthorizationHeader {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$Token,
+
+        [ValidateSet('Bearer', 'Basic')]
+        [string]$AuthenticationType = 'Bearer'
+    )
+
+    if ($AuthenticationType -eq 'Bearer') {
+        return @{ Authorization = "Bearer $Token" }
+    }
+
+    $basicToken = if ($Token.Contains(':')) { $Token } else { ":$Token" }
+    $encodedToken = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes($basicToken))
+    return @{ Authorization = "Basic $encodedToken" }
+}
+
+function Invoke-AdoApiRequest {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$Uri,
+
+        [Parameter(Mandatory)]
+        [hashtable]$Headers
+    )
+
+    $response = Invoke-WebRequest -Uri $Uri -Headers $Headers -Method Get -SkipHttpErrorCheck
+    if ($response.StatusCode -lt 200 -or $response.StatusCode -ge 300) {
+        throw "Azure DevOps API request failed with HTTP $($response.StatusCode) for $Uri. $($response.StatusDescription)"
+    }
+
+    return $response
+}
+
+function Get-GHAzDORepository {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$OrganizationUri,
+
+        [Parameter(Mandatory)]
+        [string]$Project,
+
+        [Parameter(Mandatory)]
+        [string]$Repository,
+
+        [Parameter(Mandatory)]
+        [hashtable]$Headers,
+
+        [scriptblock]$RequestInvoker = ${function:Invoke-AdoApiRequest}
+    )
+
+    $baseUri = $OrganizationUri.TrimEnd('/')
+    $escapedProject = [Uri]::EscapeDataString($Project)
+    $escapedRepository = [Uri]::EscapeDataString($Repository)
+    $uri = "$baseUri/$escapedProject/_apis/git/repositories/$escapedRepository`?api-version=7.2"
+    $response = & $RequestInvoker -Uri $uri -Headers $Headers
+    $repositoryResponse = $response.Content | ConvertFrom-Json -Depth 20
+
+    if ([string]::IsNullOrWhiteSpace([string](Get-PropertyValue $repositoryResponse id)) -or
+        [string]::IsNullOrWhiteSpace([string](Get-PropertyValue $repositoryResponse name))) {
+        throw "Azure DevOps returned incomplete repository metadata for '$Project/$Repository'."
+    }
+
+    return $repositoryResponse
+}
+
+function Get-ContinuationToken {
+    param(
+        [Parameter(Mandatory)]
+        [object]$Response
+    )
+
+    $token = $Response.Headers['x-ms-continuationtoken']
+    if ($null -eq $token) {
+        return $null
+    }
+
+    if ($token -is [System.Collections.IEnumerable] -and $token -isnot [string]) {
+        $token = @($token)[0]
+    }
+
+    if ([string]::IsNullOrWhiteSpace([string]$token)) {
+        return $null
+    }
+
+    return [string]$token
+}
+
+function Get-GHAzDOAlert {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$Organization,
+
+        [Parameter(Mandatory)]
+        [string]$Project,
+
+        [Parameter(Mandatory)]
+        [string]$Repository,
+
+        [Parameter(Mandatory)]
+        [ValidateSet('code', 'dependency', 'secret')]
+        [string]$AlertType,
+
+        [Parameter(Mandatory)]
+        [hashtable]$Headers,
+
+        [string]$Ref,
+
+        [ValidateRange(1, 1000)]
+        [int]$PageSize = 1000,
+
+        [scriptblock]$RequestInvoker = ${function:Invoke-AdoApiRequest}
+    )
+
+    $alerts = [Collections.Generic.List[object]]::new()
+    $continuationToken = $null
+
+    do {
+        $query = [Collections.Generic.List[string]]::new()
+        $query.Add("top=$PageSize")
+        $query.Add('criteria.states=active')
+        $query.Add("criteria.alertType=$([Uri]::EscapeDataString($AlertType))")
+
+        if ($AlertType -eq 'secret') {
+            $query.Add('criteria.confidenceLevels=high')
+            $query.Add('criteria.confidenceLevels=other')
+        }
+        elseif (-not [string]::IsNullOrWhiteSpace($Ref)) {
+            $query.Add("criteria.ref=$([Uri]::EscapeDataString($Ref))")
+        }
+
+        if (-not [string]::IsNullOrWhiteSpace($continuationToken)) {
+            $query.Add("continuationToken=$([Uri]::EscapeDataString($continuationToken))")
+        }
+
+        $query.Add('api-version=7.2-preview.1')
+        $escapedOrganization = [Uri]::EscapeDataString($Organization)
+        $escapedProject = [Uri]::EscapeDataString($Project)
+        $escapedRepository = [Uri]::EscapeDataString($Repository)
+        $uri = "https://advsec.dev.azure.com/$escapedOrganization/$escapedProject/_apis/alert/repositories/$escapedRepository/alerts?$($query -join '&')"
+        $response = & $RequestInvoker -Uri $uri -Headers $Headers
+        $body = $response.Content | ConvertFrom-Json -Depth 100
+
+        $responseAlerts = Get-PropertyValue $body value
+        if ($null -eq $responseAlerts) {
+            throw "Azure DevOps returned an invalid alert response for '$Project/$Repository' ($AlertType)."
+        }
+
+        foreach ($alert in @($responseAlerts)) {
+            $alerts.Add($alert)
+        }
+
+        $continuationToken = Get-ContinuationToken -Response $response
+    } while ($null -ne $continuationToken)
+
+    return $alerts.ToArray()
+}
+
+function Get-GHAzDOAlertSnapshot {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$Organization,
+
+        [Parameter(Mandatory)]
+        [string]$Project,
+
+        [Parameter(Mandatory)]
+        [string]$Repository,
+
+        [Parameter(Mandatory)]
+        [hashtable]$Headers,
+
+        [string]$Ref,
+
+        [ValidateRange(1, 1000)]
+        [int]$PageSize = 1000,
+
+        [scriptblock]$RequestInvoker = ${function:Invoke-AdoApiRequest}
+    )
+
+    $alerts = [Collections.Generic.List[object]]::new()
+    foreach ($alertType in @('dependency', 'code', 'secret')) {
+        $typeAlerts = Get-GHAzDOAlert `
+            -Organization $Organization `
+            -Project $Project `
+            -Repository $Repository `
+            -AlertType $alertType `
+            -Headers $Headers `
+            -Ref $Ref `
+            -PageSize $PageSize `
+            -RequestInvoker $RequestInvoker
+
+        foreach ($alert in $typeAlerts) {
+            $alerts.Add($alert)
+        }
+    }
+
+    return $alerts.ToArray()
+}
+
+function Get-AlertSnapshotSignature {
+    param(
+        [Parameter(Mandatory)]
+        [AllowEmptyCollection()]
+        [object[]]$Alerts
+    )
+
+    $signatureInput = @(
+        $Alerts |
+            ForEach-Object {
+                '{0}|{1}|{2}|{3}' -f
+                (Get-PropertyValue $_ alertId),
+                (Get-PropertyValue $_ alertType),
+                (Get-PropertyValue $_ state),
+                (Get-PropertyValue $_ lastSeenDate)
+            } |
+            Sort-Object
+    ) -join "`n"
+
+    $bytes = [Text.Encoding]::UTF8.GetBytes($signatureInput)
+    return [Convert]::ToHexString([Security.Cryptography.SHA256]::HashData($bytes))
+}
+
+function Wait-GHAzDOAlertSnapshot {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$Organization,
+
+        [Parameter(Mandatory)]
+        [string]$Project,
+
+        [Parameter(Mandatory)]
+        [string]$Repository,
+
+        [Parameter(Mandatory)]
+        [hashtable]$Headers,
+
+        [string]$Ref,
+
+        [ValidateRange(1, 3600)]
+        [int]$TimeoutSeconds = 180,
+
+        [ValidateRange(1, 300)]
+        [int]$IntervalSeconds = 15,
+
+        [ValidateRange(1, 10)]
+        [int]$StableIterations = 2,
+
+        [ValidateRange(1, 1000)]
+        [int]$PageSize = 1000,
+
+        [scriptblock]$RequestInvoker = ${function:Invoke-AdoApiRequest}
+    )
+
+    $stopwatch = [Diagnostics.Stopwatch]::StartNew()
+    $previousSignature = $null
+    $stableCount = 0
+    $latestAlerts = @()
+
+    while ($stopwatch.Elapsed.TotalSeconds -lt $TimeoutSeconds) {
+        $latestAlerts = @(
+            Get-GHAzDOAlertSnapshot `
+                -Organization $Organization `
+                -Project $Project `
+                -Repository $Repository `
+                -Headers $Headers `
+                -Ref $Ref `
+                -PageSize $PageSize `
+                -RequestInvoker $RequestInvoker
+        )
+        $signature = Get-AlertSnapshotSignature -Alerts $latestAlerts
+
+        if ($signature -eq $previousSignature) {
+            $stableCount++
+        }
+        else {
+            $previousSignature = $signature
+            $stableCount = 1
+        }
+
+        if ($stableCount -ge $StableIterations) {
+            return $latestAlerts
+        }
+
+        Start-Sleep -Seconds $IntervalSeconds
+    }
+
+    throw "GHAzDO alerts did not stabilize within $TimeoutSeconds seconds for '$Project/$Repository'."
+}
+
+function ConvertTo-NucleusSeverity {
+    param(
+        [AllowNull()]
+        [object]$Severity
+    )
+
+    switch (([string]$Severity).ToLowerInvariant()) {
+        'critical' { return 'Critical' }
+        'high' { return 'High' }
+        'error' { return 'High' }
+        'medium' { return 'Medium' }
+        'warning' { return 'Medium' }
+        'low' { return 'Low' }
+        default { return 'Informational' }
+    }
+}
+
+function Get-AlertRule {
+    param(
+        [Parameter(Mandatory)]
+        [object]$Alert
+    )
+
+    $rules = [Collections.Generic.List[object]]::new()
+    foreach ($tool in @((Get-PropertyValue $Alert tools))) {
+        foreach ($rule in @((Get-PropertyValue $tool rules))) {
+            $rules.Add([pscustomobject]@{
+                    Tool = [string](Get-PropertyValue $tool name)
+                    Rule = $rule
+                })
+        }
+    }
+
+    return $rules.ToArray()
+}
+
+function Get-RuleIdentifier {
+    param(
+        [Parameter(Mandatory)]
+        [object]$Alert,
+
+        [Parameter(Mandatory)]
+        [string]$Organization
+    )
+
+    $ruleEntries = @(Get-AlertRule -Alert $Alert)
+    if ($ruleEntries.Count -gt 0) {
+        $entry = $ruleEntries[0]
+        $opaqueId = Get-PropertyValue $entry.Rule opaqueId
+        $id = Get-PropertyValue $entry.Rule id
+        $friendlyName = Get-PropertyValue $entry.Rule friendlyName
+        $ruleId = if (-not [string]::IsNullOrWhiteSpace([string]$opaqueId)) {
+            [string]$opaqueId
+        }
+        elseif (-not [string]::IsNullOrWhiteSpace([string]$id)) {
+            [string]$id
+        }
+        else {
+            [string]$friendlyName
+        }
+
+        if (-not [string]::IsNullOrWhiteSpace($ruleId)) {
+            return ConvertTo-ConstrainedAscii `
+                -Value "GHAZDO:$($Alert.alertType):$($entry.Tool):$ruleId" `
+                -MaximumLength 250
+        }
+    }
+
+    # Alert ID is the safest collision-free fallback, but it cannot group
+    # separate instances when normalized rule metadata is unavailable.
+    return ConvertTo-ConstrainedAscii `
+        -Value "GHAZDO:$(Get-PropertyValue $Alert alertType):${Organization}:$(Get-PropertyValue $Alert alertId)" `
+        -MaximumLength 250
+}
+
+function Get-RuleText {
+    param(
+        [Parameter(Mandatory)]
+        [object]$Alert,
+
+        [Parameter(Mandatory)]
+        [ValidateSet('description', 'helpMessage')]
+        [string]$Property
+    )
+
+    $values = @(
+        Get-AlertRule -Alert $Alert |
+            ForEach-Object { [string](Get-PropertyValue $_.Rule $Property) } |
+            Where-Object { -not [string]::IsNullOrWhiteSpace($_) } |
+            Select-Object -Unique
+    )
+
+    if ($values.Count -eq 0) {
+        return $null
+    }
+
+    return $values -join "`n`n"
+}
+
+function Get-CveAndCweReference {
+    param(
+        [Parameter(Mandatory)]
+        [object]$Alert
+    )
+
+    $ruleJson = @(Get-AlertRule -Alert $Alert | ForEach-Object { $_.Rule }) |
+        ConvertTo-Json -Depth 30 -Compress
+    $references = @(
+        [regex]::Matches($ruleJson, '(?i)\b(?:CVE-\d{4}-\d{4,}|CWE-\d+)\b') |
+            ForEach-Object { $_.Value.ToUpperInvariant() } |
+            Select-Object -Unique
+    )
+
+    if ($references.Count -eq 0) {
+        return $null
+    }
+
+    return ConvertTo-ConstrainedAscii -Value ($references -join ',') -MaximumLength 512
+}
+
+function Get-FirstPhysicalLocation {
+    param(
+        [Parameter(Mandatory)]
+        [object]$Alert
+    )
+
+    $locations = @((Get-PropertyValue $Alert physicalLocations))
+    if ($locations.Count -eq 0) {
+        return $null
+    }
+
+    return $locations[0]
+}
+
+function Get-GHAzDODependencyInfo {
+    param(
+        [Parameter(Mandatory)]
+        [object]$Alert
+    )
+
+    $locations = @((Get-PropertyValue $Alert logicalLocations))
+    $component = $locations |
+        Where-Object { ([string](Get-PropertyValue $_ kind)) -match '(?i)component' } |
+        Select-Object -First 1
+    if ($null -eq $component -and $locations.Count -gt 0) {
+        $component = $locations[-1]
+    }
+
+    $ecosystem = $null
+    $package = $null
+    $version = $null
+    if ($null -ne $component -and
+        -not [string]::IsNullOrWhiteSpace([string](Get-PropertyValue $component fullyQualifiedName))) {
+        $qualifiedName = [string](Get-PropertyValue $component fullyQualifiedName)
+        $parts = $qualifiedName.Split(' ', 2, [StringSplitOptions]::RemoveEmptyEntries)
+        if ($parts.Count -eq 2) {
+            $ecosystem = $parts[0]
+            $packageAndVersion = $parts[1]
+        }
+        else {
+            $packageAndVersion = $qualifiedName
+        }
+
+        if ($packageAndVersion -match '^(?<package>.+)@(?<version>[^@]+)$') {
+            $package = $Matches.package
+            $version = $Matches.version
+        }
+        elseif ($packageAndVersion -match '^(?<package>\S+)\s+(?<version>\d\S*)$') {
+            $package = $Matches.package
+            $version = $Matches.version
+        }
+        else {
+            $package = $packageAndVersion
+        }
+    }
+
+    $rootDependency = $locations |
+        Where-Object { ([string](Get-PropertyValue $_ kind)) -match '(?i)rootDependency' } |
+        Select-Object -First 1
+
+    return [pscustomobject]@{
+        Ecosystem = ConvertTo-ConstrainedAscii -Value $ecosystem -MaximumLength 128
+        Package = ConvertTo-ConstrainedAscii -Value $package -MaximumLength 256
+        Version = ConvertTo-ConstrainedAscii -Value $version -MaximumLength 128
+        RootDependency = ConvertTo-ConstrainedAscii `
+            -Value (Get-PropertyValue $rootDependency fullyQualifiedName) `
+            -MaximumLength 512
+    }
+}
+
+function Add-ReferenceValue {
+    param(
+        [Parameter(Mandatory)]
+        [System.Collections.Specialized.OrderedDictionary]$References,
+
+        [Parameter(Mandatory)]
+        [string]$Name,
+
+        [AllowNull()]
+        [object]$Value
+    )
+
+    if ($null -ne $Value -and -not [string]::IsNullOrWhiteSpace([string]$Value)) {
+        $References[$Name] = ConvertTo-ConstrainedAscii -Value $Value
+    }
+}
+
+function ConvertTo-NucleusFinding {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [object]$Alert,
+
+        [Parameter(Mandatory)]
+        [string]$Organization
+    )
+
+    if (([string](Get-PropertyValue $Alert state)).ToLowerInvariant() -ne 'active') {
+        return $null
+    }
+
+    $ruleEntries = @(Get-AlertRule -Alert $Alert)
+    $toolNames = @($ruleEntries | ForEach-Object { $_.Tool } | Where-Object { $_ } | Select-Object -Unique)
+    $ruleIds = @(
+        $ruleEntries |
+            ForEach-Object {
+                $opaqueId = Get-PropertyValue $_.Rule opaqueId
+                $id = Get-PropertyValue $_.Rule id
+                if (-not [string]::IsNullOrWhiteSpace([string]$opaqueId)) {
+                    [string]$opaqueId
+                }
+                elseif (-not [string]::IsNullOrWhiteSpace([string]$id)) {
+                    [string]$id
+                }
+            } |
+            Where-Object { $_ } |
+            Select-Object -Unique
+    )
+    $categories = @(
+        $ruleEntries |
+            ForEach-Object {
+                Get-PropertyValue $_.Rule @('additionalProperties', 'category')
+            } |
+            Where-Object { -not [string]::IsNullOrWhiteSpace([string]$_) } |
+            Select-Object -Unique
+    )
+
+    $location = Get-FirstPhysicalLocation -Alert $Alert
+    $references = [ordered]@{}
+    Add-ReferenceValue -References $references -Name 'GHAzDO Alert ID' -Value (Get-PropertyValue $Alert alertId)
+    Add-ReferenceValue -References $references -Name 'Alert Type' -Value (Get-PropertyValue $Alert alertType)
+    Add-ReferenceValue -References $references -Name 'State' -Value (Get-PropertyValue $Alert state)
+    Add-ReferenceValue -References $references -Name 'Tool' -Value ($toolNames -join ',')
+    Add-ReferenceValue -References $references -Name 'Rule ID' -Value ($ruleIds -join ',')
+    Add-ReferenceValue -References $references -Name 'Category' -Value ($categories -join ',')
+    Add-ReferenceValue -References $references -Name 'Git Ref' -Value (Get-PropertyValue $Alert gitRef)
+    Add-ReferenceValue -References $references -Name 'Repository URL' -Value (Get-PropertyValue $Alert repositoryUrl)
+    Add-ReferenceValue -References $references -Name 'Commit' -Value (Get-PropertyValue $location @('versionControl', 'commitHash'))
+    Add-ReferenceValue -References $references -Name 'Confidence' -Value (Get-PropertyValue $Alert confidence)
+    Add-ReferenceValue -References $references -Name 'Secret Validity' -Value (Get-PropertyValue $Alert @('validityDetails', 'validityStatus'))
+    Add-ReferenceValue -References $references -Name 'Secret Validity Last Checked' -Value (Get-PropertyValue $Alert @('validityDetails', 'validityLastCheckedDate'))
+    $repositoryUrl = Get-PropertyValue $Alert repositoryUrl
+    $alertId = Get-PropertyValue $Alert alertId
+    if ($null -ne $repositoryUrl -and $null -ne $alertId) {
+        Add-ReferenceValue `
+            -References $references `
+            -Name 'Alert URL' `
+            -Value "$repositoryUrl/alerts/$alertId"
+    }
+
+    $finding = [ordered]@{
+        finding_type = 'Vuln'
+        finding_number = Get-RuleIdentifier -Alert $Alert -Organization $Organization
+        finding_name = ConvertTo-ConstrainedAscii -Value (Get-PropertyValue $Alert title) -MaximumLength 128
+        finding_severity = ConvertTo-NucleusSeverity -Severity (Get-PropertyValue $Alert severity)
+        finding_result = 'Failed'
+        finding_references = $references
+    }
+
+    $description = Get-RuleText -Alert $Alert -Property description
+    if ($null -ne $description) {
+        $finding.finding_description = $description
+    }
+
+    $recommendation = Get-RuleText -Alert $Alert -Property helpMessage
+    if ($null -ne $recommendation) {
+        $finding.finding_recommendation = $recommendation
+    }
+
+    $cveReferences = Get-CveAndCweReference -Alert $Alert
+    if ($null -ne $cveReferences) {
+        $finding.finding_cve = $cveReferences
+    }
+
+    $firstSeenDate = Get-PropertyValue $Alert firstSeenDate
+    if ($null -ne $firstSeenDate) {
+        $finding.finding_discovered = ([datetime]$firstSeenDate).ToUniversalTime().ToString('yyyy-MM-dd HH:mm:ss')
+    }
+
+    if ($null -ne $location) {
+        $filePath = Get-PropertyValue $location filePath
+        $lineStart = Get-PropertyValue $location @('region', 'lineStart')
+        if (-not [string]::IsNullOrWhiteSpace([string]$filePath)) {
+            $finding.finding_path = ConvertTo-ConstrainedAscii -Value $filePath -MaximumLength 4096
+        }
+
+        if ($null -ne $lineStart -and ([string]$lineStart) -match '^\d+$') {
+            $finding.finding_line_number = [string]$lineStart
+        }
+    }
+
+    if (([string](Get-PropertyValue $Alert alertType)).ToLowerInvariant() -eq 'dependency') {
+        $dependency = Get-GHAzDODependencyInfo -Alert $Alert
+        if (-not [string]::IsNullOrWhiteSpace($dependency.Package)) {
+            $finding.finding_package = $dependency.Package
+        }
+        if (-not [string]::IsNullOrWhiteSpace($dependency.Version)) {
+            $finding.finding_package_version = $dependency.Version
+        }
+
+        Add-ReferenceValue -References $references -Name 'Ecosystem' -Value $dependency.Ecosystem
+        Add-ReferenceValue -References $references -Name 'Root Dependency' -Value $dependency.RootDependency
+
+        if ($finding.Contains('finding_path') -and $finding.Contains('finding_package')) {
+            $finding.finding_sub_type = 'path_package'
+        }
+        elseif ($finding.Contains('finding_package')) {
+            $finding.finding_sub_type = 'package_only'
+        }
+        else {
+            $finding.finding_sub_type = 'path_only'
+        }
+    }
+    else {
+        $finding.finding_sub_type = 'path_only'
+    }
+
+    return [pscustomobject]$finding
+}
+
+function Sync-FindingProperty {
+    param(
+        [Parameter(Mandatory)]
+        [object]$Finding,
+
+        [Parameter(Mandatory)]
+        [string]$Name,
+
+        [AllowNull()]
+        [object]$Value
+    )
+
+    $property = $Finding.PSObject.Properties[$Name]
+    if ($null -eq $property) {
+        $Finding | Add-Member -NotePropertyName $Name -NotePropertyValue $Value
+    }
+    else {
+        $property.Value = $Value
+    }
+}
+
+function Sync-NucleusUniqueFindingField {
+    param(
+        [Parameter(Mandatory)]
+        [AllowEmptyCollection()]
+        [object[]]$Findings
+    )
+
+    $severityRank = @{
+        Informational = 0
+        Low = 1
+        Medium = 2
+        High = 3
+        Critical = 4
+    }
+    $subTypeRank = @{
+        path_only = 1
+        package_only = 2
+        path_package = 3
+    }
+
+    foreach ($group in @($Findings | Group-Object -Property finding_number)) {
+        $instances = @(
+            $group.Group |
+                Sort-Object {
+                    [string](Get-PropertyValue $_ @('finding_references', 'GHAzDO Alert ID'))
+                }
+        )
+        $canonical = $instances[0]
+
+        $severity = $instances |
+            Sort-Object { $severityRank[[string]$_.finding_severity] } -Descending |
+            Select-Object -First 1 -ExpandProperty finding_severity
+        $subType = $instances |
+            Where-Object { $null -ne $_.PSObject.Properties['finding_sub_type'] } |
+            Sort-Object { $subTypeRank[[string]$_.finding_sub_type] } -Descending |
+            Select-Object -First 1 -ExpandProperty finding_sub_type
+        $cve = @(
+            $instances |
+                ForEach-Object {
+                    [string](Get-PropertyValue $_ finding_cve) -split ','
+                } |
+                Where-Object { -not [string]::IsNullOrWhiteSpace($_) } |
+                Select-Object -Unique
+        ) -join ','
+
+        foreach ($instance in $instances) {
+            foreach ($fieldName in @(
+                    'finding_name',
+                    'finding_description',
+                    'finding_recommendation'
+                )) {
+                $value = Get-PropertyValue $canonical $fieldName
+                if ($null -ne $value) {
+                    Sync-FindingProperty -Finding $instance -Name $fieldName -Value $value
+                }
+            }
+
+            Sync-FindingProperty -Finding $instance -Name finding_severity -Value $severity
+            if (-not [string]::IsNullOrWhiteSpace([string]$subType)) {
+                Sync-FindingProperty -Finding $instance -Name finding_sub_type -Value $subType
+            }
+            if (-not [string]::IsNullOrWhiteSpace($cve)) {
+                Sync-FindingProperty `
+                    -Finding $instance `
+                    -Name finding_cve `
+                    -Value (ConvertTo-ConstrainedAscii $cve -MaximumLength 512)
+            }
+        }
+    }
+
+    return $Findings
+}
+
+function ConvertTo-NucleusFlexConnect {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [AllowEmptyCollection()]
+        [object[]]$Alerts,
+
+        [Parameter(Mandatory)]
+        [object]$Repository,
+
+        [Parameter(Mandatory)]
+        [string]$Organization,
+
+        [Parameter(Mandatory)]
+        [string]$Project,
+
+        [Parameter(Mandatory)]
+        [string]$Ref,
+
+        [datetime]$ScanDate = (Get-Date).ToUniversalTime()
+    )
+
+    $findings = @(
+        foreach ($alert in $Alerts) {
+            $finding = ConvertTo-NucleusFinding -Alert $alert -Organization $Organization
+            if ($null -ne $finding) {
+                $finding
+            }
+        }
+    )
+    $findings = @(Sync-NucleusUniqueFindingField -Findings $findings)
+
+    $asset = [ordered]@{
+        host_name = ConvertTo-ConstrainedAscii -Value (Get-PropertyValue $Repository id)
+        app_name_secondary = @(
+            ConvertTo-ConstrainedAscii -Value "$Organization/$Project/$(Get-PropertyValue $Repository name)"
+        )
+        app_branch = ConvertTo-ConstrainedAscii -Value $Ref
+        app_repo_url = ConvertTo-ConstrainedAscii -Value (Get-PropertyValue $Repository webUrl)
+        asset_info = [ordered]@{
+            'azuredevops.organization' = ConvertTo-ConstrainedAscii -Value $Organization
+            'azuredevops.project' = ConvertTo-ConstrainedAscii -Value $Project
+            'azuredevops.repository-id' = ConvertTo-ConstrainedAscii -Value (Get-PropertyValue $Repository id)
+            'azuredevops.repository-name' = ConvertTo-ConstrainedAscii -Value (Get-PropertyValue $Repository name)
+        }
+        findings = $findings
+    }
+
+    return [pscustomobject][ordered]@{
+        nucleus_import_version = '1'
+        scan_tool = 'GHAZDO'
+        scan_type = 'Application'
+        scan_date = $ScanDate.ToUniversalTime().ToString('yyyy-MM-dd HH:mm:ss +00:00')
+        assets = @([pscustomobject]$asset)
+    }
+}
+
+function Test-GHAzDODefaultBranch {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$CurrentRef,
+
+        [Parameter(Mandatory)]
+        [object]$Repository
+    )
+
+    $defaultBranch = [string](Get-PropertyValue $Repository defaultBranch)
+    if ([string]::IsNullOrWhiteSpace($defaultBranch)) {
+        throw 'The Azure DevOps repository response did not include a defaultBranch value.'
+    }
+
+    return $CurrentRef -eq $defaultBranch
+}
+
+function Write-NucleusFlexConnect {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [object]$FlexConnect,
+
+        [Parameter(Mandatory)]
+        [string]$Path
+    )
+
+    $directory = Split-Path -Path $Path -Parent
+    if (-not [string]::IsNullOrWhiteSpace($directory)) {
+        $null = New-Item -Path $directory -ItemType Directory -Force
+    }
+
+    $FlexConnect |
+        ConvertTo-Json -Depth 100 |
+        Set-Content -Path $Path -Encoding utf8NoBOM
+
+    return (Resolve-Path -Path $Path).Path
+}
+
+function Send-NucleusScan {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$NucleusBaseUrl,
+
+        [Parameter(Mandatory)]
+        [string]$NucleusProjectId,
+
+        [Parameter(Mandatory)]
+        [string]$ApiKey,
+
+        [Parameter(Mandatory)]
+        [string]$Path,
+
+        [scriptblock]$UploadInvoker = {
+            param($Uri, $Headers, $Form)
+            Invoke-WebRequest `
+                -Uri $Uri `
+                -Method Post `
+                -Headers $Headers `
+                -Form $Form `
+                -SkipHttpErrorCheck
+        }
+    )
+
+    if (-not (Test-Path -Path $Path -PathType Leaf)) {
+        throw "The FlexConnect file '$Path' does not exist."
+    }
+
+    $endpoint = '{0}/api/projects/{1}/scans' -f
+        $NucleusBaseUrl.TrimEnd('/'),
+        [Uri]::EscapeDataString($NucleusProjectId)
+    $headers = @{ 'x-apikey' = $ApiKey }
+    $form = @{ file = Get-Item -Path $Path }
+    $response = & $UploadInvoker -Uri $endpoint -Headers $headers -Form $form
+
+    if ($response.StatusCode -lt 200 -or $response.StatusCode -ge 300) {
+        throw "Nucleus scan upload failed with HTTP $($response.StatusCode). $($response.StatusDescription)"
+    }
+
+    return $response
+}
+
+Export-ModuleMember -Function @(
+    'ConvertTo-NucleusFinding',
+    'ConvertTo-NucleusFlexConnect',
+    'Get-GHAzDOAlert',
+    'Get-GHAzDOAlertSnapshot',
+    'Get-GHAzDORepository',
+    'Get-AdoAuthorizationHeader',
+    'Send-NucleusScan',
+    'Test-GHAzDODefaultBranch',
+    'Wait-GHAzDOAlertSnapshot',
+    'Write-NucleusFlexConnect'
+)

--- a/src/nucleus/Invoke-GHAzDONucleus.ps1
+++ b/src/nucleus/Invoke-GHAzDONucleus.ps1
@@ -1,0 +1,179 @@
+<#
+.SYNOPSIS
+    Exports GHAzDO alerts to Nucleus through a FlexConnect scan.
+.DESCRIPTION
+    Retrieves a complete active snapshot of code, dependency, and secret alerts
+    for one Azure DevOps repository, converts the alerts to FlexConnect JSON,
+    and optionally uploads the file to a Nucleus project.
+.PARAMETER AdoToken
+    Azure DevOps OAuth token or PAT. Defaults to SYSTEM_ACCESSTOKEN, then
+    MAPPED_ADO_PAT.
+.PARAMETER AdoAuthenticationType
+    Bearer for System.AccessToken or Basic for a PAT.
+.PARAMETER DryRun
+    Generates the FlexConnect file without uploading it to Nucleus.
+#>
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+    'PSAvoidUsingWriteHost',
+    '',
+    Justification = 'Azure Pipelines logging commands require host output.'
+)]
+[CmdletBinding()]
+param(
+    [string]$OrganizationUri = $env:SYSTEM_COLLECTIONURI,
+    [string]$Project = $env:SYSTEM_TEAMPROJECT,
+    [string]$Repository = $env:BUILD_REPOSITORY_NAME,
+    [string]$Ref = $env:BUILD_SOURCEBRANCH,
+    [string]$AdoToken,
+    [ValidateSet('Bearer', 'Basic')]
+    [string]$AdoAuthenticationType,
+    [string]$NucleusBaseUrl = $env:NUCLEUS_BASE_URL,
+    [string]$NucleusProjectId = $env:NUCLEUS_PROJECT_ID,
+    [string]$NucleusApiKey = $env:NUCLEUS_API_KEY,
+    [string]$OutputPath,
+    [ValidateRange(1, 3600)]
+    [int]$WaitTimeoutSeconds = 180,
+    [ValidateRange(1, 300)]
+    [int]$WaitIntervalSeconds = 15,
+    [ValidateRange(1, 10)]
+    [int]$StableIterations = 2,
+    [ValidateRange(1, 1000)]
+    [int]$PageSize = 1000,
+    [switch]$DryRun,
+    [switch]$PublishArtifact
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+Import-Module (Join-Path $PSScriptRoot 'GHAzDONucleus.psm1') -Force
+
+if ([string]::IsNullOrWhiteSpace($AdoToken)) {
+    if (-not [string]::IsNullOrWhiteSpace($env:SYSTEM_ACCESSTOKEN)) {
+        $AdoToken = $env:SYSTEM_ACCESSTOKEN
+        $AdoAuthenticationType = 'Bearer'
+    }
+    elseif (-not [string]::IsNullOrWhiteSpace($env:MAPPED_ADO_PAT)) {
+        $AdoToken = $env:MAPPED_ADO_PAT
+        $AdoAuthenticationType = 'Basic'
+    }
+}
+
+if ([string]::IsNullOrWhiteSpace($AdoAuthenticationType)) {
+    $AdoAuthenticationType = 'Bearer'
+}
+
+foreach ($requiredValue in @{
+        OrganizationUri = $OrganizationUri
+        Project = $Project
+        Repository = $Repository
+        Ref = $Ref
+        AdoToken = $AdoToken
+    }.GetEnumerator()) {
+    if ([string]::IsNullOrWhiteSpace([string]$requiredValue.Value)) {
+        throw "The $($requiredValue.Key) value is required."
+    }
+}
+
+if (-not $DryRun) {
+    foreach ($requiredValue in @{
+            NucleusBaseUrl = $NucleusBaseUrl
+            NucleusProjectId = $NucleusProjectId
+            NucleusApiKey = $NucleusApiKey
+        }.GetEnumerator()) {
+        if ([string]::IsNullOrWhiteSpace([string]$requiredValue.Value)) {
+            throw "The $($requiredValue.Key) value is required unless -DryRun is used."
+        }
+    }
+}
+
+$organizationMatch = [regex]::Match(
+    $OrganizationUri,
+    '^https://dev\.azure\.com/(?<organization>[^/]+)/?$',
+    [Text.RegularExpressions.RegexOptions]::IgnoreCase
+)
+if (-not $organizationMatch.Success) {
+    throw "OrganizationUri must use the Azure DevOps Services format 'https://dev.azure.com/{organization}'."
+}
+$organization = $organizationMatch.Groups['organization'].Value
+$headers = Get-AdoAuthorizationHeader `
+    -Token $AdoToken `
+    -AuthenticationType $AdoAuthenticationType
+$repositoryMetadata = Get-GHAzDORepository `
+    -OrganizationUri $OrganizationUri `
+    -Project $Project `
+    -Repository $Repository `
+    -Headers $headers
+
+Write-Host "Waiting for the active GHAzDO alert snapshot to stabilize for $Project/$Repository..."
+$alerts = @(
+    Wait-GHAzDOAlertSnapshot `
+        -Organization $organization `
+        -Project $Project `
+        -Repository $repositoryMetadata.id `
+        -Headers $headers `
+        -Ref $Ref `
+        -TimeoutSeconds $WaitTimeoutSeconds `
+        -IntervalSeconds $WaitIntervalSeconds `
+        -StableIterations $StableIterations `
+        -PageSize $PageSize
+)
+
+$defaultBranch = [string]$repositoryMetadata.defaultBranch
+if ($Ref -ne $defaultBranch) {
+    $secretCount = @($alerts | Where-Object alertType -eq 'secret').Count
+    if ($secretCount -gt 0) {
+        Write-Warning (
+            "Omitting $secretCount repository-level secret alerts from the non-default branch asset '$Ref'. " +
+            "Secret alerts are exported with the default branch to avoid duplicating them across branch assets."
+        )
+        $alerts = @($alerts | Where-Object alertType -ne 'secret')
+    }
+}
+
+$codeCount = @($alerts | Where-Object alertType -eq 'code').Count
+$dependencyCount = @($alerts | Where-Object alertType -eq 'dependency').Count
+$secretCount = @($alerts | Where-Object alertType -eq 'secret').Count
+Write-Host (
+    'Collected {0} active alerts (code: {1}, dependency: {2}, secret: {3}).' -f
+    $alerts.Count,
+    $codeCount,
+    $dependencyCount,
+    $secretCount
+)
+
+$flexConnect = ConvertTo-NucleusFlexConnect `
+    -Alerts $alerts `
+    -Repository $repositoryMetadata `
+    -Organization $organization `
+    -Project $Project `
+    -Ref $Ref
+
+if ([string]::IsNullOrWhiteSpace($OutputPath)) {
+    $outputDirectory = if (-not [string]::IsNullOrWhiteSpace($env:BUILD_ARTIFACTSTAGINGDIRECTORY)) {
+        $env:BUILD_ARTIFACTSTAGINGDIRECTORY
+    }
+    else {
+        $PWD.Path
+    }
+    $safeRepositoryName = $repositoryMetadata.name -replace '[^\w.-]', '-'
+    $OutputPath = Join-Path $outputDirectory "ghazdo-nucleus-$safeRepositoryName.json"
+}
+
+$resolvedOutputPath = Write-NucleusFlexConnect -FlexConnect $flexConnect -Path $OutputPath
+Write-Host "Generated FlexConnect scan at $resolvedOutputPath."
+
+if ($PublishArtifact -and $env:TF_BUILD -eq 'True') {
+    Write-Host "##vso[artifact.upload artifactname=NucleusFlexConnect]$resolvedOutputPath"
+}
+
+if ($DryRun) {
+    Write-Host 'Dry run complete; the scan was not uploaded to Nucleus.'
+    return
+}
+
+$null = Send-NucleusScan `
+    -NucleusBaseUrl $NucleusBaseUrl `
+    -NucleusProjectId $NucleusProjectId `
+    -ApiKey $NucleusApiKey `
+    -Path $resolvedOutputPath
+Write-Host 'Nucleus accepted the FlexConnect scan upload.'

--- a/src/nucleus/README.md
+++ b/src/nucleus/README.md
@@ -2,16 +2,64 @@
 
 This integration exports GitHub Advanced Security for Azure DevOps (GHAzDO)
 alerts to a Nucleus project. It provides a file-based approximation of the
-native Nucleus GitHub Advanced Security connector:
+native Nucleus GitHub Advanced Security connector.
 
-```text
-GHAzDO scanning and alert processing
-  -> Azure DevOps Advanced Security Alerts API
-  -> FlexConnect JSON
-  -> Nucleus scan upload API
+## Architecture
+
+```mermaid
+flowchart LR
+    subgraph Pipeline["Azure Pipelines"]
+        Restore["Restore dependencies"]
+        SCA["GHAzDO dependency scanning"]
+        CodeQL["GHAzDO CodeQL analysis"]
+        ThirdParty["Optional third-party scanner"]
+        Publish["AdvancedSecurity-Publish@1"]
+        ExportTask["PowerShell export task"]
+
+        Restore --> SCA
+        Restore --> CodeQL
+        ThirdParty -. "SARIF" .-> Publish
+        SCA --> ExportTask
+        CodeQL --> ExportTask
+        Publish -. "Optional" .-> ExportTask
+    end
+
+    subgraph GHAzDO["Azure DevOps Advanced Security"]
+        Processing["Alert processing"]
+        AlertsAPI["Alerts REST API"]
+        Processing --> AlertsAPI
+    end
+
+    subgraph Integration["PowerShell integration"]
+        Exporter["Invoke-GHAzDONucleus.ps1"]
+        Mapping["GHAzDO to FlexConnect mapping"]
+        ScanFile["FlexConnect JSON scan"]
+        Exporter --> Mapping --> ScanFile
+    end
+
+    subgraph Nucleus["Nucleus"]
+        UploadAPI["Project scan upload API"]
+        Ingestion["FlexConnect ingestion"]
+        Findings["Application assets and findings"]
+        UploadAPI --> Ingestion --> Findings
+    end
+
+    SCA --> Processing
+    CodeQL --> Processing
+    Publish --> Processing
+    ExportTask --> Exporter
+    Exporter -- "Paginated GET" --> AlertsAPI
+    AlertsAPI -- "Active alerts" --> Exporter
+    ScanFile --> UploadAPI
 ```
 
-It supports active:
+The scanner tasks publish results to GHAzDO first. The exporter does not parse
+CodeQL output, dependency manifests, or SARIF directly. It reads normalized
+alerts from the GHAzDO Alerts API, waits for a stable active snapshot, maps that
+snapshot to a Nucleus FlexConnect scan, and uploads the scan as one bulk
+ingestion payload.
+
+The integration supports active:
 
 - Code alerts from CodeQL and normalized third-party SARIF publishers
 - Dependency/SCA alerts

--- a/src/nucleus/README.md
+++ b/src/nucleus/README.md
@@ -1,0 +1,275 @@
+# GHAzDO to Nucleus FlexConnect
+
+This integration exports GitHub Advanced Security for Azure DevOps (GHAzDO)
+alerts to a Nucleus project. It provides a file-based approximation of the
+native Nucleus GitHub Advanced Security connector:
+
+```text
+GHAzDO scanning and alert processing
+  -> Azure DevOps Advanced Security Alerts API
+  -> FlexConnect JSON
+  -> Nucleus scan upload API
+```
+
+It supports active:
+
+- Code alerts from CodeQL and normalized third-party SARIF publishers
+- Dependency/SCA alerts
+- Secret-scanning alerts at both `High` and `Other` confidence
+
+This is not a native or bidirectional connector. It does not synchronize
+GHAzDO dismissal reasons or manual statuses back to Nucleus.
+
+## Files
+
+| File | Purpose |
+| --- | --- |
+| `Invoke-GHAzDONucleus.ps1` | Retrieves, converts, writes, and uploads one repository snapshot |
+| `GHAzDONucleus.psm1` | API, pagination, mapping, serialization, and upload functions |
+| `ghazdo-nucleus-template.yml` | Basic .NET/NuGet pipeline steps template |
+| `Test-GHAzDODefaultBranch.ps1` | Optional default-branch filter helper |
+| `tests/Test-GHAzDONucleus.ps1` | Fixture-driven validation without external test modules |
+
+## Prerequisites
+
+1. Enable GHAzDO for the Azure Repos Git repository.
+2. Create a Nucleus project and API key.
+3. Grant the pipeline identity permission to read the repository and Advanced
+   Security alerts. For local PAT use, grant:
+   - Advanced Security: Read
+   - Code: Read
+4. Store these Azure Pipelines variables:
+
+| Variable | Secret | Example |
+| --- | ---: | --- |
+| `nucleus-base-url` | No | `https://example.nucleussec.com/nucleus` |
+| `nucleus-project-id` | No | Nucleus project ID |
+| `nucleus-api-key` | Yes | Nucleus user API key |
+
+The template maps `$(System.AccessToken)` into the PowerShell task and uses
+Bearer authentication. If the job OAuth token cannot be granted the required
+permissions, map a PAT into `MAPPED_ADO_PAT`; the script uses Basic
+authentication for that fallback.
+
+Do not place either token on the command line or in source control.
+
+## Basic .NET pipeline
+
+Copy the `src/nucleus` directory into the repository being scanned, then
+reference the template:
+
+```yaml
+trigger:
+  branches:
+    include:
+      - main
+
+pool:
+  vmImage: ubuntu-latest
+
+steps:
+  - template: src/nucleus/ghazdo-nucleus-template.yml
+```
+
+The template deliberately uses a basic flow:
+
+1. Initialize CodeQL with `buildtype: None`.
+2. Authenticate NuGet feeds and explicitly restore .NET dependencies.
+3. Run `AdvancedSecurity-Dependency-Scanning@1`.
+4. Run `AdvancedSecurity-Codeql-Analyze@1` with
+   `WaitForProcessing: true`.
+5. Wait for a stable Alerts API snapshot and upload it to Nucleus.
+
+An explicit restore is important because dependency scanning can complete
+without detecting components when packages have not been restored.
+`buildtype: None` and this restore sequence are a simple .NET example, not
+universal build guidance. Adapt initialization and build steps for other
+languages and repository layouts.
+
+### Processing behavior
+
+`AdvancedSecurity-Codeql-Analyze@1` has a documented processing wait.
+`AdvancedSecurity-Dependency-Scanning@1` does not. The template runs dependency
+scanning first so its results can process while CodeQL runs. The exporter then
+polls complete active snapshots until two consecutive snapshots match.
+
+This is bounded, best-effort dependency readiness. The public Alerts API cannot
+prove that a dependency scan with zero findings has completed processing.
+Increase the wait timeout, interval, or stable-iteration values in the template
+for slower environments.
+
+## Optional default-branch filtering
+
+Nucleus treats the branch as part of an Application asset's identity. Running
+only on the default branch generally produces the most stable asset inventory,
+but branch filtering is not required by the integration.
+
+The optional helper queries the repository's real `defaultBranch` and sets
+`RunNucleusIngestion`:
+
+```yaml
+steps:
+  - task: PowerShell@2
+    displayName: Check repository default branch
+    inputs:
+      targetType: filePath
+      filePath: src/nucleus/Test-GHAzDODefaultBranch.ps1
+      pwsh: true
+    env:
+      SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+
+  - template: src/nucleus/ghazdo-nucleus-template.yml
+```
+
+The template runs unless `RunNucleusIngestion` is explicitly set to `false`.
+Without this helper, it exports the current `Build.SourceBranch` as a separate
+Nucleus Application branch asset.
+
+## Dry run and local use
+
+Generate and inspect FlexConnect JSON without uploading:
+
+```powershell
+$env:MAPPED_ADO_PAT = '<Azure DevOps PAT>'
+
+pwsh ./src/nucleus/Invoke-GHAzDONucleus.ps1 `
+  -OrganizationUri 'https://dev.azure.com/contoso' `
+  -Project 'security' `
+  -Repository 'payments' `
+  -Ref 'refs/heads/main' `
+  -AdoAuthenticationType Basic `
+  -DryRun
+```
+
+The default pipeline output is
+`$(Build.ArtifactStagingDirectory)/ghazdo-nucleus-<repository>.json`.
+`-PublishArtifact` uploads that JSON as the `NucleusFlexConnect` pipeline
+artifact for troubleshooting. The file contains vulnerability metadata and
+should be retained according to the organization's security-data policy.
+
+## FlexConnect mapping
+
+### Scan and asset
+
+| FlexConnect field | GHAzDO value |
+| --- | --- |
+| `nucleus_import_version` | `1` |
+| `scan_tool` | Stable value `GHAZDO` |
+| `scan_type` | `Application` |
+| `scan_date` | UTC snapshot completion time |
+| `host_name` | Stable Azure DevOps repository ID |
+| `app_name_secondary` | `organization/project/repository` |
+| `app_branch` | Pipeline Git ref |
+| `app_repo_url` | Azure DevOps repository web URL |
+| `asset_info` | Organization, project, repository ID, and repository name |
+
+### Findings
+
+| FlexConnect field | GHAzDO value |
+| --- | --- |
+| `finding_number` | Alert type + tool + stable rule/advisory ID |
+| `finding_name` | Alert title, constrained to 128 ASCII characters |
+| `finding_severity` | GHAzDO/SARIF severity normalized to a Nucleus severity |
+| `finding_description` | Rule description |
+| `finding_recommendation` | Rule help message |
+| `finding_cve` | CVE and CWE identifiers found in rule metadata |
+| `finding_discovered` | `firstSeenDate` |
+| `finding_path` | First physical location path |
+| `finding_line_number` | First physical location start line |
+| `finding_package` | Conservatively parsed vulnerable component |
+| `finding_package_version` | Component version when explicitly represented |
+| `finding_references` | Alert ID/type/state, tool, rule, category, ref, commit, URL, and non-secret metadata |
+
+`finding_number` identifies the Nucleus unique finding. The organization-wide
+GHAzDO `alertId` remains instance metadata so repeated instances of the same
+rule group together instead of creating one unique finding per alert.
+
+Package formats vary by ecosystem. The exporter only populates package/version
+fields when the normalized logical location can be parsed without guessing;
+the raw root dependency remains in references.
+
+Fields that Nucleus scopes to the unique finding are normalized across every
+instance sharing a `finding_number`: the highest severity and most complete
+subtype win, CVE/CWE values are combined, and the lowest alert ID supplies
+stable name/description/recommendation text.
+
+## Snapshot and status semantics
+
+Every upload is a complete snapshot of active findings for the selected
+repository/ref. Because GHAzDO secret alerts are repository-level rather than
+branch-scoped, they are included with the default-branch asset and omitted from
+non-default branch assets to avoid duplication. The exporter intentionally does
+not use `modifiedSince`; a delta file could cause Nucleus to resolve alerts that
+were merely omitted.
+
+Nucleus can mark an instance resolved via scan when it disappears from a later
+snapshot. FlexConnect does not communicate why it disappeared. A GHAzDO alert
+that is fixed, dismissed, auto-dismissed, accepted risk, or false positive is
+therefore absent from the active snapshot, but its GHAzDO reason is not mapped
+to a corresponding Nucleus manual status. Native connector parity would require
+a supported status API workflow or a first-party Nucleus connector.
+
+## Third-party SARIF
+
+The exporter is tool-agnostic for normalized GHAzDO `code` alerts. A compatible
+third-party workflow can:
+
+1. Run the scanner and produce SARIF.
+2. Publish it to GHAzDO using `AdvancedSecurity-Publish@1`.
+3. Set `WaitForProcessing: true` on the publish task.
+4. Run `Invoke-GHAzDONucleus.ps1` after the publish task.
+
+Example publish step, intentionally not included in the basic template:
+
+```yaml
+- task: AdvancedSecurity-Publish@1
+  displayName: Publish third-party SARIF
+  inputs:
+    SarifsInputDirectory: $(Build.SourcesDirectory)/sarif
+    EnableRecursiveScanning: true
+    Category: third-party
+    WaitForProcessing: true
+    WaitForProcessingInterval: 5
+    WaitForProcessingTimeout: 300
+```
+
+Microsoft currently documents `AdvancedSecurity-Publish@1` for SARIF produced
+by non-Microsoft tasks, including the Infrastructure-as-Code Scanning Tasks
+extension. Confirm compatibility with the specific scanner before relying on
+this path. The publish task is not needed for CodeQL analysis or dependency
+scanning tasks.
+
+## Secret safety
+
+- The API request never asks for `ValidationFingerprint`.
+- Both `High` and `Other` confidence levels are requested explicitly.
+- `truncatedSecret`, validation fingerprints, and secret values are not copied
+  into FlexConnect output or logs.
+- Secret validity and confidence can be included as non-secret references.
+- API keys and Azure DevOps tokens are only supplied through environment
+  variables or secure parameters.
+
+## Validation
+
+Run the fixture-driven checks:
+
+```powershell
+pwsh -NoProfile -File ./src/nucleus/tests/Test-GHAzDONucleus.ps1
+```
+
+Run static analysis:
+
+```powershell
+Invoke-ScriptAnalyzer -Path ./src/nucleus -Recurse
+```
+
+## References
+
+- [GHAzDO Alerts - List REST API](https://learn.microsoft.com/rest/api/azure/devops/advancedsecurity/alerts/list)
+- [CodeQL Analyze task](https://learn.microsoft.com/azure/devops/pipelines/tasks/reference/advanced-security-codeql-analyze-v1)
+- [Dependency Scanning task](https://learn.microsoft.com/azure/devops/pipelines/tasks/reference/advanced-security-dependency-scanning-v1)
+- [Advanced Security Publish task](https://learn.microsoft.com/azure/devops/pipelines/tasks/reference/advanced-security-publish-v1)
+- [Nucleus FlexConnect file schema](https://help.nucleussec.com/docs/flexconnect-framework)
+- [Nucleus Application assets](https://help.nucleussec.com/docs/applications)
+- [Nucleus vulnerability findings](https://help.nucleussec.com/docs/findings-1)
+- [Nucleus scan upload example](https://help.nucleussec.com/docs/posting-a-custom-scan-file-to-nucleus-via-api-using-python3-requests-library-1)

--- a/src/nucleus/Test-GHAzDODefaultBranch.ps1
+++ b/src/nucleus/Test-GHAzDODefaultBranch.ps1
@@ -1,0 +1,57 @@
+<#
+.SYNOPSIS
+    Emits an Azure Pipelines variable indicating whether the current build is
+    running on the repository default branch.
+#>
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+    'PSAvoidUsingWriteHost',
+    '',
+    Justification = 'Azure Pipelines logging commands require host output.'
+)]
+[CmdletBinding()]
+param(
+    [string]$OrganizationUri = $env:SYSTEM_COLLECTIONURI,
+    [string]$Project = $env:SYSTEM_TEAMPROJECT,
+    [string]$Repository = $env:BUILD_REPOSITORY_NAME,
+    [string]$CurrentRef = $env:BUILD_SOURCEBRANCH,
+    [string]$AdoToken = $env:SYSTEM_ACCESSTOKEN,
+    [ValidateSet('Bearer', 'Basic')]
+    [string]$AdoAuthenticationType = 'Bearer',
+    [string]$VariableName = 'RunNucleusIngestion'
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+Import-Module (Join-Path $PSScriptRoot 'GHAzDONucleus.psm1') -Force
+
+foreach ($requiredValue in @{
+        OrganizationUri = $OrganizationUri
+        Project = $Project
+        Repository = $Repository
+        CurrentRef = $CurrentRef
+        AdoToken = $AdoToken
+    }.GetEnumerator()) {
+    if ([string]::IsNullOrWhiteSpace([string]$requiredValue.Value)) {
+        throw "The $($requiredValue.Key) value is required."
+    }
+}
+
+$headers = Get-AdoAuthorizationHeader `
+    -Token $AdoToken `
+    -AuthenticationType $AdoAuthenticationType
+$repositoryMetadata = Get-GHAzDORepository `
+    -OrganizationUri $OrganizationUri `
+    -Project $Project `
+    -Repository $Repository `
+    -Headers $headers
+$isDefaultBranch = Test-GHAzDODefaultBranch `
+    -CurrentRef $CurrentRef `
+    -Repository $repositoryMetadata
+$variableValue = $isDefaultBranch.ToString().ToLowerInvariant()
+
+Write-Host "Current ref: $CurrentRef; default ref: $($repositoryMetadata.defaultBranch)."
+if ($env:TF_BUILD -eq 'True') {
+    Write-Host "##vso[task.setvariable variable=$VariableName]$variableValue"
+}
+
+return $isDefaultBranch

--- a/src/nucleus/ghazdo-nucleus-template.yml
+++ b/src/nucleus/ghazdo-nucleus-template.yml
@@ -1,0 +1,53 @@
+# Basic .NET example for scanning one Azure Repos Git repository and uploading
+# the resulting active GHAzDO alert snapshot to Nucleus.
+steps:
+  - task: AdvancedSecurity-Codeql-Init@1
+    displayName: Initialize CodeQL
+    condition: and(succeeded(), ne(variables['RunNucleusIngestion'], 'false'))
+    inputs:
+      languages: csharp
+      buildtype: None
+
+  - task: NuGetAuthenticate@1
+    displayName: Authenticate NuGet feeds
+    condition: and(succeeded(), ne(variables['RunNucleusIngestion'], 'false'))
+
+  - task: DotNetCoreCLI@2
+    displayName: Restore .NET dependencies
+    condition: and(succeeded(), ne(variables['RunNucleusIngestion'], 'false'))
+    inputs:
+      command: restore
+      projects: '**/*.sln'
+
+  # Dependency scanning has no WaitForProcessing input. Running it before
+  # CodeQL analysis gives the service additional processing time.
+  - task: AdvancedSecurity-Dependency-Scanning@1
+    displayName: Run dependency scanning
+    condition: and(succeeded(), ne(variables['RunNucleusIngestion'], 'false'))
+
+  - task: AdvancedSecurity-Codeql-Analyze@1
+    displayName: Run CodeQL analysis
+    condition: and(succeeded(), ne(variables['RunNucleusIngestion'], 'false'))
+    inputs:
+      WaitForProcessing: true
+      WaitForProcessingInterval: 5
+      WaitForProcessingTimeout: 300
+
+  - task: PowerShell@2
+    displayName: Upload GHAzDO alerts to Nucleus
+    condition: and(succeeded(), ne(variables['RunNucleusIngestion'], 'false'))
+    inputs:
+      targetType: filePath
+      filePath: src/nucleus/Invoke-GHAzDONucleus.ps1
+      pwsh: true
+      arguments: >-
+        -WaitTimeoutSeconds 180
+        -WaitIntervalSeconds 15
+        -StableIterations 2
+        -PageSize 1000
+        -PublishArtifact
+    env:
+      SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+      NUCLEUS_BASE_URL: $(nucleus-base-url)
+      NUCLEUS_PROJECT_ID: $(nucleus-project-id)
+      NUCLEUS_API_KEY: $(nucleus-api-key)

--- a/src/nucleus/tests/Test-GHAzDONucleus.ps1
+++ b/src/nucleus/tests/Test-GHAzDONucleus.ps1
@@ -1,0 +1,217 @@
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+    'PSUseSingularNouns',
+    '',
+    Justification = 'Test assertion and fixture helper names read naturally in plural form.'
+)]
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+    'PSAvoidUsingPositionalParameters',
+    '',
+    Justification = 'Concise assertions keep the test cases readable.'
+)]
+[CmdletBinding()]
+param()
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+$modulePath = Join-Path $PSScriptRoot '..\GHAzDONucleus.psm1'
+Import-Module $modulePath -Force
+
+$script:TestCount = 0
+
+function Assert-Equal {
+    param(
+        [Parameter(Mandatory)]
+        [AllowNull()]
+        [object]$Actual,
+
+        [Parameter(Mandatory)]
+        [AllowNull()]
+        [object]$Expected,
+
+        [Parameter(Mandatory)]
+        [string]$Message
+    )
+
+    $script:TestCount++
+    if ($Actual -ne $Expected) {
+        throw "$Message Expected '$Expected', received '$Actual'."
+    }
+}
+
+function Assert-True {
+    param(
+        [Parameter(Mandatory)]
+        [bool]$Condition,
+
+        [Parameter(Mandatory)]
+        [string]$Message
+    )
+
+    $script:TestCount++
+    if (-not $Condition) {
+        throw $Message
+    }
+}
+
+function Assert-Throws {
+    param(
+        [Parameter(Mandatory)]
+        [scriptblock]$Action,
+
+        [Parameter(Mandatory)]
+        [string]$Message
+    )
+
+    $script:TestCount++
+    try {
+        & $Action
+    }
+    catch {
+        return
+    }
+
+    throw $Message
+}
+
+function Read-FixtureAlerts {
+    param(
+        [Parameter(Mandatory)]
+        [string]$Name
+    )
+
+    $fixturePath = Join-Path $PSScriptRoot "fixtures\$Name"
+    return @((Get-Content -Path $fixturePath -Raw | ConvertFrom-Json -Depth 100).value)
+}
+
+$repository = [pscustomobject]@{
+    id = '11111111-2222-3333-4444-555555555555'
+    name = 'payments'
+    webUrl = 'https://dev.azure.com/contoso/security/_git/payments'
+    defaultBranch = 'refs/heads/main'
+}
+$alerts = @(
+    Read-FixtureAlerts 'codeql-alerts.json'
+    Read-FixtureAlerts 'dependency-alerts.json'
+    Read-FixtureAlerts 'secret-alerts.json'
+    Read-FixtureAlerts 'third-party-alerts.json'
+)
+$duplicateThirdParty = (
+    (Read-FixtureAlerts 'third-party-alerts.json')[0] |
+        ConvertTo-Json -Depth 100 |
+        ConvertFrom-Json -Depth 100
+)
+$duplicateThirdParty.alertId = 402
+$duplicateThirdParty.severity = 'low'
+$alerts += $duplicateThirdParty
+
+$scan = ConvertTo-NucleusFlexConnect `
+    -Alerts $alerts `
+    -Repository $repository `
+    -Organization 'contoso' `
+    -Project 'security' `
+    -Ref 'refs/heads/main' `
+    -ScanDate ([datetime]'2026-08-10T14:00:00Z')
+
+Assert-Equal $scan.scan_tool 'GHAZDO' 'The scan source must remain stable.'
+Assert-Equal $scan.scan_type 'Application' 'The scan must create Application assets.'
+Assert-Equal $scan.assets.Count 1 'The scan should contain one repository asset.'
+Assert-Equal $scan.assets[0].host_name $repository.id 'The stable repository ID should identify the asset.'
+Assert-Equal $scan.assets[0].findings.Count 5 'Only active alerts should become findings.'
+
+$codeFinding = $scan.assets[0].findings |
+    Where-Object { $_.finding_references['GHAzDO Alert ID'] -eq '101' }
+Assert-Equal $codeFinding.finding_number 'GHAZDO:code:CodeQL:cs/sql-injection' 'CodeQL rules should correlate by tool and rule.'
+Assert-Equal $codeFinding.finding_path 'src/Database.cs' 'Code paths should be preserved.'
+Assert-Equal $codeFinding.finding_line_number '42' 'Code line numbers should be preserved.'
+Assert-True ($codeFinding.finding_cve -match 'CWE-089') 'CWE references should be extracted.'
+
+$dependencyFinding = $scan.assets[0].findings |
+    Where-Object { $_.finding_references['GHAzDO Alert ID'] -eq '201' }
+Assert-Equal $dependencyFinding.finding_package 'Newtonsoft.Json' 'Dependency package names should be parsed.'
+Assert-Equal $dependencyFinding.finding_package_version '12.0.1' 'Dependency package versions should be parsed.'
+Assert-Equal $dependencyFinding.finding_sub_type 'path_package' 'Dependency findings should expose path and package columns.'
+Assert-True ($dependencyFinding.finding_cve -match 'CVE-2024-21907') 'Dependency CVEs should be extracted.'
+
+$thirdPartyFindings = @($scan.assets[0].findings |
+    Where-Object { $_.finding_number -eq 'GHAZDO:code:ThirdPartyIaC:iac/public-storage' })
+$thirdPartyFinding = $thirdPartyFindings |
+    Where-Object { $_.finding_references['GHAzDO Alert ID'] -eq '401' }
+Assert-Equal $thirdPartyFinding.finding_number 'GHAZDO:code:ThirdPartyIaC:iac/public-storage' 'Third-party code alerts should use normalized tool/rule identity.'
+Assert-Equal $thirdPartyFinding.finding_severity 'Medium' 'SARIF warning severity should map to Medium.'
+Assert-Equal $thirdPartyFinding.finding_references.Category 'iac' 'Third-party SARIF categories should be retained.'
+Assert-True (
+    @($thirdPartyFindings | Where-Object finding_severity -ne 'Medium').Count -eq 0
+) 'Unique finding severity should be normalized to the highest instance severity.'
+
+$json = $scan | ConvertTo-Json -Depth 100
+Assert-True (-not $json.Contains('DO-NOT-EXPORT-TRUNCATED-SECRET')) 'Truncated secrets must not be exported.'
+Assert-True (-not $json.Contains('DO-NOT-EXPORT-VALIDATION-FINGERPRINT')) 'Validation fingerprints must not be exported.'
+
+Assert-True (
+    Test-GHAzDODefaultBranch -CurrentRef 'refs/heads/main' -Repository $repository
+) 'The default branch helper should recognize the default branch.'
+Assert-True (
+    -not (Test-GHAzDODefaultBranch -CurrentRef 'refs/heads/feature' -Repository $repository)
+) 'The default branch helper should reject a different branch.'
+
+$script:RequestUris = [Collections.Generic.List[string]]::new()
+$script:RequestNumber = 0
+$requestInvoker = {
+    param($Uri, $Headers)
+    $null = $Headers
+    $script:RequestUris.Add($Uri)
+    $script:RequestNumber++
+    if ($script:RequestNumber -eq 1) {
+        return [pscustomobject]@{
+            StatusCode = 200
+            Headers = @{ 'x-ms-continuationtoken' = 'next token/1' }
+            Content = '{"count":1,"value":[{"alertId":1}]}'
+        }
+    }
+
+    return [pscustomobject]@{
+        StatusCode = 200
+        Headers = @{}
+        Content = '{"count":1,"value":[{"alertId":2}]}'
+    }
+}
+
+$pagedAlerts = @(
+    Get-GHAzDOAlert `
+        -Organization 'contoso' `
+        -Project 'security' `
+        -Repository $repository.id `
+        -AlertType secret `
+        -Headers @{ Authorization = 'test' } `
+        -RequestInvoker $requestInvoker
+)
+Assert-Equal $pagedAlerts.Count 2 'Pagination should retrieve every page.'
+Assert-True ($script:RequestUris[1] -match 'continuationToken=next%20token%2F1') 'Continuation tokens must be encoded.'
+Assert-True ($script:RequestUris[0] -match 'criteria\.confidenceLevels=high') 'High-confidence secrets should be requested.'
+Assert-True ($script:RequestUris[0] -match 'criteria\.confidenceLevels=other') 'Other-confidence secrets should be requested.'
+Assert-True (-not ($script:RequestUris[0] -match 'ValidationFingerprint')) 'Secret validation fingerprints must never be requested.'
+
+$tempFile = Join-Path ([IO.Path]::GetTempPath()) "ghazdo-nucleus-test-$([guid]::NewGuid()).json"
+try {
+    Set-Content -Path $tempFile -Value '{}' -Encoding utf8NoBOM
+    Assert-Throws -Message 'Nucleus upload failures must propagate.' -Action {
+        Send-NucleusScan `
+            -NucleusBaseUrl 'https://example.invalid/nucleus' `
+            -NucleusProjectId '1' `
+            -ApiKey 'not-a-real-key' `
+            -Path $tempFile `
+            -UploadInvoker {
+                param($Uri, $Headers, $Form)
+                $null = $Uri, $Headers, $Form
+                [pscustomobject]@{
+                    StatusCode = 500
+                    StatusDescription = 'Test failure'
+                }
+            }
+    }
+}
+finally {
+    Remove-Item -Path $tempFile -Force -ErrorAction SilentlyContinue
+}
+
+Write-Output "Passed $script:TestCount GHAzDO Nucleus integration assertions."

--- a/src/nucleus/tests/fixtures/codeql-alerts.json
+++ b/src/nucleus/tests/fixtures/codeql-alerts.json
@@ -1,0 +1,54 @@
+{
+  "count": 2,
+  "value": [
+    {
+      "alertId": 101,
+      "alertType": "code",
+      "state": "active",
+      "title": "SQL query built from user-controlled sources",
+      "severity": "high",
+      "firstSeenDate": "2026-08-01T13:20:00Z",
+      "lastSeenDate": "2026-08-10T13:20:00Z",
+      "gitRef": "refs/heads/main",
+      "repositoryUrl": "https://dev.azure.com/contoso/security/_git/payments",
+      "tools": [
+        {
+          "name": "CodeQL",
+          "rules": [
+            {
+              "opaqueId": "cs/sql-injection",
+              "friendlyName": "SQL injection",
+              "description": "Building SQL from untrusted input may allow injection.",
+              "helpMessage": "Use parameterized queries.",
+              "tags": [
+                "external/cwe/cwe-089"
+              ]
+            }
+          ]
+        }
+      ],
+      "physicalLocations": [
+        {
+          "filePath": "src/Database.cs",
+          "region": {
+            "lineStart": 42
+          },
+          "versionControl": {
+            "commitHash": "abcdef1234567890"
+          }
+        }
+      ],
+      "logicalLocations": []
+    },
+    {
+      "alertId": 102,
+      "alertType": "code",
+      "state": "dismissed",
+      "title": "Dismissed test alert",
+      "severity": "medium",
+      "tools": [],
+      "physicalLocations": [],
+      "logicalLocations": []
+    }
+  ]
+}

--- a/src/nucleus/tests/fixtures/dependency-alerts.json
+++ b/src/nucleus/tests/fixtures/dependency-alerts.json
@@ -1,0 +1,55 @@
+{
+  "count": 1,
+  "value": [
+    {
+      "alertId": 201,
+      "alertType": "dependency",
+      "state": "active",
+      "title": "Vulnerable Newtonsoft.Json package",
+      "severity": "critical",
+      "firstSeenDate": "2026-08-02T10:00:00Z",
+      "lastSeenDate": "2026-08-10T10:00:00Z",
+      "gitRef": "refs/heads/main",
+      "repositoryUrl": "https://dev.azure.com/contoso/security/_git/payments",
+      "tools": [
+        {
+          "name": "GitHub Advanced Security dependency scanning",
+          "rules": [
+            {
+              "opaqueId": "GHSA-5crp-9r3c-p9vr",
+              "friendlyName": "Improper handling of metadata",
+              "description": "A vulnerable package version is installed.",
+              "helpMessage": "Upgrade to a non-vulnerable package version.",
+              "additionalProperties": {
+                "identifiers": [
+                  "CVE-2024-21907"
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "physicalLocations": [
+        {
+          "filePath": "src/App/packages.lock.json",
+          "region": {
+            "lineStart": 15
+          },
+          "versionControl": {
+            "commitHash": "1234567890abcdef"
+          }
+        }
+      ],
+      "logicalLocations": [
+        {
+          "kind": "rootDependency",
+          "fullyQualifiedName": "nuget Example.App 1.0.0"
+        },
+        {
+          "kind": "component",
+          "fullyQualifiedName": "nuget Newtonsoft.Json 12.0.1"
+        }
+      ]
+    }
+  ]
+}

--- a/src/nucleus/tests/fixtures/secret-alerts.json
+++ b/src/nucleus/tests/fixtures/secret-alerts.json
@@ -1,0 +1,47 @@
+{
+  "count": 1,
+  "value": [
+    {
+      "alertId": 301,
+      "alertType": "secret",
+      "state": "active",
+      "title": "Azure storage account key detected",
+      "severity": "critical",
+      "confidence": "high",
+      "firstSeenDate": "2026-08-03T08:00:00Z",
+      "lastSeenDate": "2026-08-10T08:00:00Z",
+      "repositoryUrl": "https://dev.azure.com/contoso/security/_git/payments",
+      "truncatedSecret": "DO-NOT-EXPORT-TRUNCATED-SECRET",
+      "validationFingerprint": "DO-NOT-EXPORT-VALIDATION-FINGERPRINT",
+      "validityDetails": {
+        "validityStatus": "active",
+        "validityLastCheckedDate": "2026-08-10T07:55:00Z"
+      },
+      "tools": [
+        {
+          "name": "GitHub Advanced Security secret scanning",
+          "rules": [
+            {
+              "opaqueId": "azure_storage_account_key",
+              "friendlyName": "Azure storage account key",
+              "description": "A credential pattern was detected.",
+              "helpMessage": "Revoke the credential and remove it from history."
+            }
+          ]
+        }
+      ],
+      "physicalLocations": [
+        {
+          "filePath": "config/settings.json",
+          "region": {
+            "lineStart": 18
+          },
+          "versionControl": {
+            "commitHash": "fedcba0987654321"
+          }
+        }
+      ],
+      "logicalLocations": []
+    }
+  ]
+}

--- a/src/nucleus/tests/fixtures/third-party-alerts.json
+++ b/src/nucleus/tests/fixtures/third-party-alerts.json
@@ -1,0 +1,48 @@
+{
+  "count": 1,
+  "value": [
+    {
+      "alertId": 401,
+      "alertType": "code",
+      "state": "active",
+      "title": "Public storage container",
+      "severity": "warning",
+      "firstSeenDate": "2026-08-04T09:00:00Z",
+      "lastSeenDate": "2026-08-10T09:00:00Z",
+      "gitRef": "refs/heads/main",
+      "repositoryUrl": "https://dev.azure.com/contoso/security/_git/payments",
+      "tools": [
+        {
+          "name": "ThirdPartyIaC",
+          "rules": [
+            {
+              "opaqueId": "iac/public-storage",
+              "friendlyName": "Public storage",
+              "description": "The infrastructure definition permits public access.",
+              "helpMessage": "Disable anonymous public access.",
+              "tags": [
+                "security",
+                "CWE-284"
+              ],
+              "additionalProperties": {
+                "category": "iac"
+              }
+            }
+          ]
+        }
+      ],
+      "physicalLocations": [
+        {
+          "filePath": "infra/storage.bicep",
+          "region": {
+            "lineStart": 12
+          },
+          "versionControl": {
+            "commitHash": "0011223344556677"
+          }
+        }
+      ],
+      "logicalLocations": []
+    }
+  ]
+}


### PR DESCRIPTION
## Why

Nucleus has a native GitHub Advanced Security connector, but no equivalent GHAzDO connector for Azure DevOps. This adds a repository-hosted path that exports normalized GHAzDO alerts through the documented REST API and ingests them into Nucleus using FlexConnect.

## What changed

- Adds a PowerShell exporter for complete active code, dependency, and secret alert snapshots, including continuation-token pagination and safe secret handling.
- Maps CodeQL and normalized third-party SARIF alerts into Nucleus Application assets and vulnerability findings with stable correlation fields.
- Adds a basic C#/.NET Azure Pipelines template that restores dependencies, runs dependency scanning before CodeQL analysis, waits for processing, and uploads the FlexConnect scan.
- Provides optional default-branch filtering, dry-run/artifact output, setup and field-mapping documentation, and fixture-driven validation.

## Important limitations

This is file-based point-in-time ingestion, not a bidirectional native connector. Nucleus can resolve findings that disappear from later active snapshots, but FlexConnect cannot preserve GHAzDO dismissal reasons or synchronize accepted-risk and false-positive states. Dependency scanning also has no documented processing-wait input, so the exporter uses bounded snapshot-stability polling after the scan tasks.